### PR TITLE
Improve and fix support for compiling protobuf files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dynamic = ["version"]
 name = "Frequenz Energy-as-a-Service GmbH"
 email = "floss@frequenz.com"
 
+[project.entry-points."distutils.commands"]
+compile_proto = "frequenz.repo.config.setuptools.grpc_tools:CompileProto"
+
 [project.optional-dependencies]
 actor = []
 api = [

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -91,7 +91,10 @@ api_command_options: _config.CommandsOptions = common_command_options.copy()
 
 api_config: _config.Config = dataclasses.replace(
     common_config,
-    source_paths=list(util.replace(common_config.source_paths, {"src": "py"})),
+    opts=api_command_options,
+    # We don't check the sources at all because they are automatically generated.
+    source_paths=[],
+    # We adapt the path to the tests.
     extra_paths=list(util.replace(common_config.extra_paths, {"tests": "pytests"})),
 )
 """Default configuration for APIs.

--- a/src/frequenz/repo/config/nox/util.py
+++ b/src/frequenz/repo/config/nox/util.py
@@ -10,7 +10,7 @@ modules in this package.
 
 import pathlib
 import tomllib
-from collections.abc import Iterable, Mapping, Set
+from collections.abc import Iterable, Mapping
 from typing import TypeVar
 
 _T = TypeVar("_T")
@@ -36,14 +36,13 @@ def replace(iterable: Iterable[_T], replacements: Mapping[_T, _T], /) -> Iterabl
 
     Args:
         iterable: The iterable to replace elements in.
-        old: The elements to replace.
-        new: The elements to replace with.
+        replacements: A mapping of elements to replace with other elements.
 
-    Returns:
-        An iterable with the elements in `iterable` replaced.
+    Yields:
+        The next element in the iterable, with the replacements applied.
 
     Example:
-        >>> assert list(replace([1, 2, 3], old={1, 2}, new={4, 5})) == [4, 5, 3]
+        >>> assert list(replace([1, 2, 3], {1: 4, 2: 5})) == [4, 5, 3]
     """
     for item in iterable:
         if item in replacements:
@@ -210,7 +209,7 @@ def discover_paths() -> list[str]:
     with open("pyproject.toml", "rb") as toml_file:
         data = tomllib.load(toml_file)
 
-    testpaths = (
+    testpaths: list[str] = (
         data.get("tool", {})
         .get("pytest", {})
         .get("ini_options", {})


### PR DESCRIPTION
The main changes are:

- Avoid running sessions on sources for API repos

  API repos are supposed to just ship python files generated from protocol buffer files. Only a stub `__init__.py` should be included, which doesn't really need to be checked.
  
  Allowing checks on the sources for an API repos triggers a lot of issues when the protocol buffers files are generated, as they don't pass any checks. An alternative would be to exclude auto-generated files, but it's not easy because each tool has its own exclusion mechanism, and some don't even have any (hello `darglint`), so it is simpler to just skip testing the stub `__init__.py` file.

- Avoid the need to write a setup.py file for API repos

  To do this we declare a distutils entry point in the `pyproject.toml` file to automatically add the `compile_proto` command using the `CompileProto` proto class.
  
  Then, in the `grpc_tools` module we just add the newly declared command as a `build` sub-command, so it is executed first. This make all other subsequent sub-commands will see the generated sources as if they were already there.
  
  The only downside of this is now we don't have an easy way to configure the command. The options are there, and can be passed via command-line, like:
  
  ```sh
  python -c 'import setuptools; setuptools.setup()' compile_proto \
      --proto-path=another/path
  ```
  
  But there is no easy way to do it in a config file, or at least at the moment I couldn't find a way to pass arbitrary options to setuptools commands in `pyproject.toml`. If we need this, we could manually parse the `pyproject.toml` file and look for options, just like `setuptools_scm` does.
