### PR TITLE
Small fixes and improvements

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -5,8 +5,4 @@
 
 from frequenz.repo.config import nox
 
-# Remove the pytest sessions because we don't have tests yet
-config = nox.default.lib_config.copy()
-config.sessions = [s for s in config.sessions if not s.startswith("pytest")]
-
-nox.configure(config)
+nox.configure(nox.default.lib_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ api = [
 ]
 app = []
 lib = []
+model = []
 dev-docs-gen = [
   "mike == 1.1.2",
   "mkdocs-gen-files == 0.4.0",

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -3,7 +3,9 @@
 
 """Frequenz project setup tools and common configuration.
 
-The tools are provided to configure 4 main types of repositories:
+The tools are provided to configure the main types of repositories most commonly used at
+Frequenz, defined in
+[`freq.repo.config.RepositoryType`][freq.repo.config.RepositoryType].
 
 - APIs (api)
 - Actors (actor)
@@ -227,8 +229,10 @@ included when compiling the protocol files.
 """
 
 from . import nox, setuptools
+from ._core import RepositoryType
 
 __all__ = [
+    "RepositoryType",
     "nox",
     "setuptools",
 ]

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -11,6 +11,7 @@ Frequenz, defined in
 - api: gRPC APIs
 - app: SDK applications
 - lib: General purpose Python libraries
+- model: SDK machine learning models
 
 # Common
 
@@ -34,8 +35,8 @@ from frequenz.repo.config import nox
 nox.configure(nox.default.lib_config)
 ```
 
-Again, make sure to pick the correct default configuration based on the type of
-your project (`actor_config`, `api_config`, `app_config`, `lib_config`).
+Again, make sure to pick the correct default configuration based on the type of your
+project (`actor_config`, `api_config`, `app_config`, `lib_config`, `model_config`).
 
 If you need to modify the configuration, you can copy one of the default
 configurations by using the

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -7,10 +7,10 @@ The tools are provided to configure the main types of repositories most commonly
 Frequenz, defined in
 [`freq.repo.config.RepositoryType`][freq.repo.config.RepositoryType].
 
-- APIs (api)
-- Actors (actor)
-- Applications (app)
-- Libraries (lib)
+- actor: SDK actors
+- api: gRPC APIs
+- app: SDK applications
+- lib: General purpose Python libraries
 
 # Common
 

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -35,7 +35,7 @@ nox.configure(nox.default.lib_config)
 ```
 
 Again, make sure to pick the correct default configuration based on the type of
-your project (`api_config`, `actor_config`, `app_config`, `lib_config`).
+your project (`actor_config`, `api_config`, `app_config`, `lib_config`).
 
 If you need to modify the configuration, you can copy one of the default
 configurations by using the

--- a/src/frequenz/repo/config/_core.py
+++ b/src/frequenz/repo/config/_core.py
@@ -3,10 +3,10 @@
 
 """Base types used accross the project."""
 
-import enum
+import enum as _enum
 
 
-class RepositoryType(enum.Enum):
+class RepositoryType(_enum.Enum):
     """Supported types of repository."""
 
     ACTOR = "actor"

--- a/src/frequenz/repo/config/_core.py
+++ b/src/frequenz/repo/config/_core.py
@@ -10,13 +10,13 @@ class RepositoryType(enum.Enum):
     """Supported types of repository."""
 
     ACTOR = "actor"
-    """Actor repository."""
+    """SDK actor repository."""
 
     API = "api"
-    """API repository."""
+    """gRPC API repository."""
 
     APP = "app"
-    """App repository."""
+    """SDK application repository."""
 
     LIB = "lib"
-    """Library repository."""
+    """General purpose library repository."""

--- a/src/frequenz/repo/config/_core.py
+++ b/src/frequenz/repo/config/_core.py
@@ -1,0 +1,22 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Base types used accross the project."""
+
+import enum
+
+
+class RepositoryType(enum.Enum):
+    """Supported types of repository."""
+
+    ACTOR = "actor"
+    """Actor repository."""
+
+    API = "api"
+    """API repository."""
+
+    APP = "app"
+    """App repository."""
+
+    LIB = "lib"
+    """Library repository."""

--- a/src/frequenz/repo/config/_core.py
+++ b/src/frequenz/repo/config/_core.py
@@ -20,3 +20,6 @@ class RepositoryType(enum.Enum):
 
     LIB = "lib"
     """General purpose library repository."""
+
+    MODEL = "model"
+    """SDK machine learning model repository."""

--- a/src/frequenz/repo/config/nox/config.py
+++ b/src/frequenz/repo/config/nox/config.py
@@ -12,37 +12,37 @@ so it can be used when implementing custom nox sessions.
 The `configure()` function must be called before `get()` is used.
 """
 
-import dataclasses
+import dataclasses as _dataclasses
 from typing import Self
 
-import nox
+import nox as _nox
 
-from . import util
+from . import util as _util
 
 
-@dataclasses.dataclass(kw_only=True, slots=True)
+@_dataclasses.dataclass(kw_only=True, slots=True)
 class CommandsOptions:
     """Command-line options for each command."""
 
-    black: list[str] = dataclasses.field(default_factory=lambda: [])
+    black: list[str] = _dataclasses.field(default_factory=lambda: [])
     """Command-line options for the `black` command."""
 
-    darglint: list[str] = dataclasses.field(default_factory=lambda: [])
+    darglint: list[str] = _dataclasses.field(default_factory=lambda: [])
     """Command-line options for the `darglint` command."""
 
-    isort: list[str] = dataclasses.field(default_factory=lambda: [])
+    isort: list[str] = _dataclasses.field(default_factory=lambda: [])
     """Command-line options for the `isort` command."""
 
-    mypy: list[str] = dataclasses.field(default_factory=lambda: [])
+    mypy: list[str] = _dataclasses.field(default_factory=lambda: [])
     """Command-line options for the `mypy` command."""
 
-    pydocstyle: list[str] = dataclasses.field(default_factory=lambda: [])
+    pydocstyle: list[str] = _dataclasses.field(default_factory=lambda: [])
     """Command-line options for the `pydocstyle` command."""
 
-    pylint: list[str] = dataclasses.field(default_factory=lambda: [])
+    pylint: list[str] = _dataclasses.field(default_factory=lambda: [])
     """Command-line options for the `pylint` command."""
 
-    pytest: list[str] = dataclasses.field(default_factory=lambda: [])
+    pytest: list[str] = _dataclasses.field(default_factory=lambda: [])
     """Command-line options for the `pytest` command."""
 
     def copy(self) -> Self:
@@ -51,20 +51,20 @@ class CommandsOptions:
         Returns:
             The copy of self.
         """
-        return dataclasses.replace(self)
+        return _dataclasses.replace(self)
 
 
-@dataclasses.dataclass(kw_only=True, slots=True)
+@_dataclasses.dataclass(kw_only=True, slots=True)
 class Config:
     """Configuration for nox sessions."""
 
-    opts: CommandsOptions = dataclasses.field(default_factory=CommandsOptions)
+    opts: CommandsOptions = _dataclasses.field(default_factory=CommandsOptions)
     """Command-line options for each command used by sessions."""
 
-    sessions: set[str] = dataclasses.field(default_factory=set)
+    sessions: set[str] = _dataclasses.field(default_factory=set)
     """List of sessions to run."""
 
-    source_paths: set[str] = dataclasses.field(default_factory=set)
+    source_paths: set[str] = _dataclasses.field(default_factory=set)
     """List of paths containing source files that should be analyzed by the sessions.
 
     Source paths are inspected for `__init__.py` files to look for packages.
@@ -77,7 +77,7 @@ class Config:
     checking.
     """
 
-    extra_paths: set[str] = dataclasses.field(default_factory=set)
+    extra_paths: set[str] = _dataclasses.field(default_factory=set)
     """List of extra paths to be analyzed by the sessions.
 
     These are not inspected for packages, as they are passed verbatim to the
@@ -89,7 +89,7 @@ class Config:
 
         This will add extra paths discovered in config files and other sources.
         """
-        for path in util.discover_paths():
+        for path in _util.discover_paths():
             if path not in self.extra_paths:
                 self.extra_paths.add(path)
 
@@ -99,9 +99,9 @@ class Config:
         Returns:
             The copy of self.
         """
-        return dataclasses.replace(self)
+        return _dataclasses.replace(self)
 
-    def path_args(self, session: nox.Session, /) -> set[str]:
+    def path_args(self, session: _nox.Session, /) -> set[str]:
         """Return the file paths to run the checks on.
 
         If positional arguments are present in the nox session, those are used
@@ -118,10 +118,10 @@ class Config:
             return set(session.posargs)
 
         return {
-            str(p) for p in util.existing_paths(self.source_paths | self.extra_paths)
+            str(p) for p in _util.existing_paths(self.source_paths | self.extra_paths)
         }
 
-    def package_args(self, session: nox.Session, /) -> set[str]:
+    def package_args(self, session: _nox.Session, /) -> set[str]:
         """Return the package names to run the checks on.
 
         If positional arguments are present in the nox session, those are used
@@ -141,18 +141,18 @@ class Config:
             return set(session.posargs)
 
         sources_package_dirs_with_roots = (
-            (p, util.find_toplevel_package_dirs(p))
-            for p in util.existing_paths(self.source_paths)
+            (p, _util.find_toplevel_package_dirs(p))
+            for p in _util.existing_paths(self.source_paths)
         )
 
         source_packages = (
-            util.path_to_package(pkg_path, root=root)
+            _util.path_to_package(pkg_path, root=root)
             for root, pkg_paths in sources_package_dirs_with_roots
             for pkg_path in pkg_paths
         )
 
         extra_packages = (
-            util.path_to_package(p) for p in util.existing_paths(self.extra_paths)
+            _util.path_to_package(p) for p in _util.existing_paths(self.extra_paths)
         )
 
         return {*source_packages, *extra_packages}
@@ -182,4 +182,4 @@ def configure(conf: Config, /) -> None:
     """
     global _config  # pylint: disable=global-statement
     _config = conf
-    nox.options.sessions = _config.sessions
+    _nox.options.sessions = _config.sessions

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -7,15 +7,14 @@ This module provides the default configuration for the different types of
 repositories defined by
 [`frequenz.repo.config.RepositoryType`][frequenz.repo.config.RepositoryType].
 
-The `lib_config`, `api_config`, `actor_config` and `app_config`
-variables are the default configurations for libraries, APIs, actors and
-applications, respectively. The `common_config` variable is the default
-configuration for all types of repositories.
+The `actor_config`, `api_config`, `app_config`, and `lib_config` variables are the
+default configurations for libraries, APIs, actors and applications, respectively. The
+`common_config` variable is the default configuration for all types of repositories.
 
-The `lib_command_options`, `api_command_options`, `actor_command_options` and
-`app_command_options` variables are the default command-line options for the same
-types of repositories, and the `common_command_options` variable is the default
-command-line options for all types of repositories.
+The `actor_command_options`, `api_command_options`, `app_command_options`, and
+`lib_command_options` variables are the default command-line options for the same types
+of repositories, and the `common_command_options` variable is the default command-line
+options for all types of repositories.
 
 They can be modified before being passed to
 [`nox.configure()`][frequenz.repo.config.nox.configure] by using the
@@ -76,11 +75,11 @@ common_config = _config.Config(
 )
 """Default configuration for all types of repositories."""
 
-lib_command_options: _config.CommandsOptions = common_command_options.copy()
-"""Default command-line options for libraries."""
+actor_command_options: _config.CommandsOptions = common_command_options.copy()
+"""Default command-line options for actors."""
 
-lib_config: _config.Config = common_config.copy()
-"""Default configuration for libraries."""
+actor_config: _config.Config = common_config.copy()
+"""Default configuration for actors."""
 
 api_command_options: _config.CommandsOptions = common_command_options.copy()
 """Default command-line options for APIs."""
@@ -99,14 +98,14 @@ Same as `common_config`, but with `source_paths` replacing `"src"` with `"py"`
 and `extra_paths` replacing `"tests"` with `"pytests"`.
 """
 
-actor_command_options: _config.CommandsOptions = common_command_options.copy()
-"""Default command-line options for actors."""
-
-actor_config: _config.Config = common_config.copy()
-"""Default configuration for actors."""
-
 app_command_options: _config.CommandsOptions = common_command_options.copy()
 """Default command-line options for applications."""
 
 app_config: _config.Config = common_config.copy()
 """Default configuration for applications."""
+
+lib_command_options: _config.CommandsOptions = common_command_options.copy()
+"""Default command-line options for libraries."""
+
+lib_config: _config.Config = common_config.copy()
+"""Default configuration for libraries."""

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -27,7 +27,7 @@ method.
 import dataclasses
 
 from . import config as _config
-from . import util
+from . import util as _util
 
 common_command_options: _config.CommandsOptions = _config.CommandsOptions(
     black=[
@@ -92,7 +92,7 @@ api_config: _config.Config = dataclasses.replace(
     # We don't check the sources at all because they are automatically generated.
     source_paths=set(),
     # We adapt the path to the tests.
-    extra_paths=set(util.replace(common_config.extra_paths, {"tests": "pytests"})),
+    extra_paths=set(_util.replace(common_config.extra_paths, {"tests": "pytests"})),
 )
 """Default configuration for APIs.
 

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -3,13 +3,9 @@
 
 """Default nox configuration for different types of repositories.
 
-This module provides the default configuration for different types of
-repositories:
-
-- Libraries (lib)
-- APIs (api)
-- Actors (actor)
-- Applications (app)
+This module provides the default configuration for the different types of
+repositories defined by
+[`frequenz.repo.config.RepositoryType`][frequenz.repo.config.RepositoryType].
 
 The `lib_config`, `api_config`, `actor_config` and `app_config`
 variables are the default configurations for libraries, APIs, actors and

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -56,24 +56,24 @@ common_command_options: _config.CommandsOptions = _config.CommandsOptions(
 
 common_config = _config.Config(
     opts=common_command_options.copy(),
-    sessions=[
+    sessions={
         "formatting",
         "mypy",
         "pylint",
         "docstrings",
         "pytest_min",
         "pytest_max",
-    ],
-    source_paths=[
+    },
+    source_paths={
         "src",
-    ],
-    extra_paths=[
+    },
+    extra_paths={
         "benchmarks",
         "docs",
         "examples",
         "noxfile.py",
         "tests",
-    ],
+    },
 )
 """Default configuration for all types of repositories."""
 
@@ -90,9 +90,9 @@ api_config: _config.Config = dataclasses.replace(
     common_config,
     opts=api_command_options,
     # We don't check the sources at all because they are automatically generated.
-    source_paths=[],
+    source_paths=set(),
     # We adapt the path to the tests.
-    extra_paths=list(util.replace(common_config.extra_paths, {"tests": "pytests"})),
+    extra_paths=set(util.replace(common_config.extra_paths, {"tests": "pytests"})),
 )
 """Default configuration for APIs.
 

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -7,14 +7,16 @@ This module provides the default configuration for the different types of
 repositories defined by
 [`frequenz.repo.config.RepositoryType`][frequenz.repo.config.RepositoryType].
 
-The `actor_config`, `api_config`, `app_config`, and `lib_config` variables are the
-default configurations for libraries, APIs, actors and applications, respectively. The
-`common_config` variable is the default configuration for all types of repositories.
+The `actor_config`, `api_config`, `app_config`, `lib_config`, and `model_config`
+variables are the default configurations for libraries, APIs, actors and applications,
+respectively. The `common_config` variable is the default configuration for all types of
+repositories.
 
-The `actor_command_options`, `api_command_options`, `app_command_options`, and
-`lib_command_options` variables are the default command-line options for the same types
-of repositories, and the `common_command_options` variable is the default command-line
-options for all types of repositories.
+The `actor_command_options`, `api_command_options`, `app_command_options`,
+`lib_command_options`, and `model_command_options` variables are the default
+command-line options for the same types of repositories, and the
+`common_command_options` variable is the default command-line options for all types of
+repositories.
 
 They can be modified before being passed to
 [`nox.configure()`][frequenz.repo.config.nox.configure] by using the
@@ -109,3 +111,9 @@ lib_command_options: _config.CommandsOptions = common_command_options.copy()
 
 lib_config: _config.Config = common_config.copy()
 """Default configuration for libraries."""
+
+model_command_options: _config.CommandsOptions = common_command_options.copy()
+"""Default command-line options for models."""
+
+model_config: _config.Config = common_config.copy()
+"""Default configuration for models."""

--- a/src/frequenz/repo/config/nox/session.py
+++ b/src/frequenz/repo/config/nox/session.py
@@ -8,7 +8,8 @@ This module defines the predefined nox sessions that are used by the default.
 
 import nox
 
-from . import config, util
+from . import config as _config
+from . import util as _util
 
 
 @nox.session
@@ -42,7 +43,7 @@ def formatting(session: nox.Session, install_deps: bool = True) -> None:
     if install_deps:
         session.install("-e", ".[dev-formatting]")
 
-    conf = config.get()
+    conf = _config.get()
     session.run("black", *conf.opts.black, *conf.path_args(session))
     session.run("isort", *conf.opts.isort, *conf.path_args(session))
 
@@ -60,8 +61,8 @@ def mypy(session: nox.Session, install_deps: bool = True) -> None:
         # fast local tests with `nox -R -e mypy`.
         session.install("-e", ".[dev-mypy]")
 
-    conf = config.get()
-    pkg_args = util.flatten(("-p", p) for p in conf.package_args(session))
+    conf = _config.get()
+    pkg_args = _util.flatten(("-p", p) for p in conf.package_args(session))
     session.run("mypy", *conf.opts.mypy, *pkg_args)
 
 
@@ -78,7 +79,7 @@ def pylint(session: nox.Session, install_deps: bool = True) -> None:
         # fast local tests with `nox -R -e pylint`.
         session.install("-e", ".[dev-pylint]")
 
-    conf = config.get()
+    conf = _config.get()
     session.run("pylint", *conf.opts.pylint, *conf.path_args(session))
 
 
@@ -93,7 +94,7 @@ def docstrings(session: nox.Session, install_deps: bool = True) -> None:
     if install_deps:
         session.install("-e", ".[dev-docstrings]")
 
-    conf = config.get()
+    conf = _config.get()
     session.run("pydocstyle", *conf.opts.pydocstyle, *conf.path_args(session))
 
     # Darglint checks that function argument and return values are documented.
@@ -136,7 +137,7 @@ def pytest_min(session: nox.Session, install_deps: bool = True) -> None:
     if install_deps:
         # install the package itself as editable, so that it is possible to do
         # fast local tests with `nox -R -e pytest_min`.
-        session.install("-e", ".[dev-pytest]", *util.min_dependencies())
+        session.install("-e", ".[dev-pytest]", *_util.min_dependencies())
 
     _pytest_impl(session, "min")
 
@@ -144,7 +145,7 @@ def pytest_min(session: nox.Session, install_deps: bool = True) -> None:
 def _pytest_impl(
     session: nox.Session, max_or_min_deps: str  # pylint: disable=unused-argument
 ) -> None:
-    conf = config.get()
+    conf = _config.get()
     session.run("pytest", *conf.opts.pytest, *session.posargs)
 
     # pylint: disable=fixme

--- a/src/frequenz/repo/config/nox/util.py
+++ b/src/frequenz/repo/config/nox/util.py
@@ -8,8 +8,8 @@ modules in this package.
 """
 
 
-import pathlib
-import tomllib
+import pathlib as _pathlib
+import tomllib as _tomllib
 from collections.abc import Iterable, Mapping
 from typing import TypeVar
 
@@ -51,7 +51,7 @@ def replace(iterable: Iterable[_T], replacements: Mapping[_T, _T], /) -> Iterabl
             yield item
 
 
-def existing_paths(paths: Iterable[str], /) -> Iterable[pathlib.Path]:
+def existing_paths(paths: Iterable[str], /) -> Iterable[_pathlib.Path]:
     """Filter paths to only leave valid paths that exist.
 
     Args:
@@ -63,10 +63,10 @@ def existing_paths(paths: Iterable[str], /) -> Iterable[pathlib.Path]:
     Example:
         >>> assert list(existing_paths([".", "/fake"])) == [pathlib.Path(".")]
     """
-    return (p for p in map(pathlib.Path, paths) if p.exists())
+    return (p for p in map(_pathlib.Path, paths) if p.exists())
 
 
-def is_python_file(path: pathlib.Path, /) -> bool:
+def is_python_file(path: _pathlib.Path, /) -> bool:
     """Check if a path is a Python file.
 
     Args:
@@ -78,7 +78,7 @@ def is_python_file(path: pathlib.Path, /) -> bool:
     return path.suffix in (".py", ".pyi")
 
 
-def path_to_package(path: pathlib.Path, root: pathlib.Path | None = None) -> str:
+def path_to_package(path: _pathlib.Path, root: _pathlib.Path | None = None) -> str:
     """Convert paths to Python package names.
 
     Paths should exist and be either a directory or a file ending with `.pyi?`
@@ -111,8 +111,8 @@ def path_to_package(path: pathlib.Path, root: pathlib.Path | None = None) -> str
 
 
 def find_toplevel_package_dirs(
-    path: pathlib.Path, /, *, root: pathlib.Path | None = None
-) -> Iterable[pathlib.Path]:
+    path: _pathlib.Path, /, *, root: _pathlib.Path | None = None
+) -> Iterable[_pathlib.Path]:
     """Find top-level packages directories in a `path`.
 
     Searches recursively for the top-level packages in `path`, relative to
@@ -176,7 +176,7 @@ def min_dependencies() -> list[str]:
 
     """
     with open("pyproject.toml", "rb") as toml_file:
-        data = tomllib.load(toml_file)
+        data = _tomllib.load(toml_file)
 
     dependencies = data.get("project", {}).get("dependencies", {})
     if not dependencies:
@@ -207,7 +207,7 @@ def discover_paths() -> list[str]:
         The discovered paths to check.
     """
     with open("pyproject.toml", "rb") as toml_file:
-        data = tomllib.load(toml_file)
+        data = _tomllib.load(toml_file)
 
     testpaths: list[str] = (
         data.get("tool", {})

--- a/src/frequenz/repo/config/setuptools/grpc_tools.py
+++ b/src/frequenz/repo/config/setuptools/grpc_tools.py
@@ -10,17 +10,17 @@ It also runs the command as the first sub-command for the build command, so
 protocol buffer files are compiled automatically before the project is built.
 """
 
-import pathlib
-import subprocess
-import sys
+import pathlib as _pathlib
+import subprocess as _subprocess
+import sys as _sys
 
-import setuptools
+import setuptools as _setuptools
 
 # The typing stub for this module is missing
-import setuptools.command.build  # type: ignore[import]
+import setuptools.command.build as _build_command  # type: ignore[import]
 
 
-class CompileProto(setuptools.Command):
+class CompileProto(_setuptools.Command):
     """Build the Python protobuf files."""
 
     proto_path: str
@@ -72,7 +72,7 @@ class CompileProto(setuptools.Command):
         """Compile the Python protobuf files."""
         include_paths = self.include_paths.split(",")
         proto_files = [
-            str(p) for p in pathlib.Path(self.proto_path).rglob(self.proto_glob)
+            str(p) for p in _pathlib.Path(self.proto_path).rglob(self.proto_glob)
         ]
 
         if not proto_files:
@@ -80,7 +80,7 @@ class CompileProto(setuptools.Command):
             return
 
         protoc_cmd = (
-            [sys.executable, "-m", "grpc_tools.protoc"]
+            [_sys.executable, "-m", "grpc_tools.protoc"]
             + [f"-I{p}" for p in [*include_paths, self.proto_path]]
             + [
                 f"--{opt}={self.py_path}"
@@ -90,7 +90,7 @@ class CompileProto(setuptools.Command):
         )
 
         print(f"Compiling proto files via: {' '.join(protoc_cmd)}")
-        subprocess.run(protoc_cmd, check=True)
+        _subprocess.run(protoc_cmd, check=True)
 
 
 # This adds the compile_proto command to the build sub-command.
@@ -98,4 +98,4 @@ class CompileProto(setuptools.Command):
 # in the [project.entry-points.distutils.commands] section.
 # The None value is an optional function that can be used to determine if the
 # sub-command should be executed or not.
-setuptools.command.build.build.sub_commands.insert(0, ("compile_proto", None))
+_build_command.build.sub_commands.insert(0, ("compile_proto", None))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the repository."""

--- a/tests/nox/__init__.py
+++ b/tests/nox/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the nox package."""

--- a/tests/nox/test_default.py
+++ b/tests/nox/test_default.py
@@ -1,0 +1,27 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the nox.default module."""
+
+from frequenz.repo import config
+from frequenz.repo.config.nox import default
+
+from .. import utils
+
+
+def test_all_repository_types_are_handled() -> None:
+    """Test that all repository types handled match the defined in RepositoryType."""
+    expected = {
+        *{f"{repo_type.value}_config" for repo_type in config.RepositoryType},
+        *{f"{repo_type.value}_command_options" for repo_type in config.RepositoryType},
+        "common_config",
+        "common_command_options",
+    }
+
+    defined = {
+        f
+        for f in dir(default)
+        if not f.startswith("_")
+        and (f.endswith("_config") or f.endswith("_command_options"))
+    }
+    assert defined == expected, utils.MSG_UNEXPECTED_REPO_TYPES

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,20 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the core module."""
+
+from frequenz.repo.config import RepositoryType
+
+from . import utils
+
+
+def test_repository_type_doesnt_have_new_types() -> None:
+    """Test that `RepositoryType` doesn't have new types."""
+    expected = {
+        "actor",
+        "api",
+        "app",
+        "lib",
+    }
+    defined = {t.value for t in RepositoryType}
+    assert defined == expected, utils.MSG_UNEXPECTED_REPO_TYPES

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,6 +15,7 @@ def test_repository_type_doesnt_have_new_types() -> None:
         "api",
         "app",
         "lib",
+        "model",
     }
     defined = {t.value for t in RepositoryType}
     assert defined == expected, utils.MSG_UNEXPECTED_REPO_TYPES

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,0 +1,24 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the pyproject.toml file."""
+
+import tomllib
+
+from frequenz.repo.config import RepositoryType
+
+from . import utils
+
+
+def test_optional_dependencies() -> None:
+    """Test that all repository types handled match the defined in RepositoryType."""
+    expected = {t.value for t in RepositoryType}
+
+    with open("pyproject.toml", "rb") as pyproject_file:
+        pyproject_toml = tomllib.load(pyproject_file)
+    defined = {
+        k
+        for k in pyproject_toml["project"]["optional-dependencies"].keys()
+        if k != "dev" and not k.startswith("dev-")
+    }
+    assert defined == expected, utils.MSG_UNEXPECTED_REPO_TYPES

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Test utilities."""
+
+MSG_UNEXPECTED_REPO_TYPES = """\
+Missing (or unexpected) repository types. Please make sure update:
+
+- the documentation (in particular in src/frequenz/repo/config/__init__.py)
+- the code (including all packages)
+- the tests
+"""


### PR DESCRIPTION
- Add a core module with RepositoryType
- Add test to check for unexpected changes in repo types
- Add test for the `nox.default` module
- Test that pyproject.toml handles all repository types
- Improve description of supported repository types
- Sort repository types alphabetically
- Add support for "model" repositories
- Use sets for config paths and sessions
- Make imports private when only used internally
