### PR TITLE
Add `--diff` as a default argument for `isort`

### DIFF
--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -37,6 +37,7 @@ common_command_options: _config.CommandsOptions = _config.CommandsOptions(
         "-v2",  # for verbose error messages.
     ],
     isort=[
+        "--diff",
         "--check",
     ],
     mypy=[


### PR DESCRIPTION
Without it, isort just complains that imports are incorrectly formatted, without showing how to fix it.