### PR TITLE
Fix escaping issues in workflows templates

### DIFF
--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/ISSUE_TEMPLATE/config.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Ask a question ❓
-    url: https://github.com/{{github_org}}/{{github_repo_name}}/discussions/new?category=support
+    url: https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.github_repo_name}}/discussions/new?category=support
     # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
     # Rename the "Q&A" category to "Support" and change the emoji to 🆘 (SOS)
     about: Use this if you are not sure how to do something, have installation problems, etc.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/labeler.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/labeler.yml
@@ -1,3 +1,4 @@
+{% raw -%}
 name: Pull Request Labeler
 
 on: [pull_request_target]
@@ -21,3 +22,4 @@ jobs:
         uses: actions/labeler@0776a679364a9a16110aac8d0f40f5e11009e327  # 4.0.4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+{%- endraw %}


### PR DESCRIPTION
- Add missing `cookiecutter` namespace in templates
- Use a raw block for template with jinja-like content
