### PR TITLE
Fix and speed up the CI workflow

### DIFF
--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
 
   create-github-release:
     name: Create GitHub release
-    needs: ["publish-docs"]
+    needs: ["build"]
     # Create a release only on tags creation
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -47,7 +47,9 @@ jobs:
           python -m pip install -e .[dev-noxfile]
 
       - name: Run nox
-        run: nox
+        # To speed things up a bit we use the speciall ci_checks_max session
+        # that uses the same venv to run multiple linting sessions
+        run: nox -e ci_checks_max pytest_min
         timeout-minutes: 10
 
   build:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ on:
   workflow_dispatch:
 
 env:
+  # Please make sure these versions are included in the `matrix`, as the
+  # `matrix` section can't use `env`, so they must be entered manually
   DEFAULT_PYTHON_VERSION: '3.11'
   DEFAULT_UBUNTU_VERSION: '20.04'
 
@@ -26,9 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-{{'${{ env.DEFAULT_UBUNTU_VERSION }}'}}
+          - ubuntu-20.04
         python:
-          - "{{'${{ env.DEFAULT_PYTHON_VERSION }}'}}"
+          - "3.11"
     runs-on: {{'${{ matrix.os }}'}}
 
     steps:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -16,10 +16,11 @@ on:
   workflow_dispatch:
 
 env:
-  # Please make sure these versions are included in the `matrix`, as the
-  # `matrix` section can't use `env`, so they must be entered manually
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
   DEFAULT_PYTHON_VERSION: '3.11'
-  DEFAULT_UBUNTU_VERSION: '20.04'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
 
 jobs:
   nox:
@@ -56,7 +57,7 @@ jobs:
 
   build:
     name: Build distribution packages
-    runs-on: ubuntu-{{'${{ env.DEFAULT_UBUNTU_VERSION }}'}}
+    runs-on: ubuntu-20.04
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
@@ -92,7 +93,7 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-{{'${{ env.DEFAULT_UBUNTU_VERSION }}'}}
+    runs-on: ubuntu-20.04
     steps:
       - name: Download distribution files
         uses: actions/download-artifact@v3
@@ -134,7 +135,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-{{'${{ env.DEFAULT_UBUNTU_VERSION }}'}}
+    runs-on: ubuntu-20.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/


### PR DESCRIPTION
- ci: Use the special `ci_checks_max` session
- ci: Don't use `env` in `matrix`
- ci: Fix dependency on non-existing job
- ci: Remove `DEFAULT_UBUNTU_VERSION`

Fixes #62.