### PR TITLE
Add RELEASE_NOTES to cookiecutter

### DIFF
--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/RELEASE_NOTES.template.md
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/RELEASE_NOTES.template.md
@@ -1,0 +1,17 @@
+# {{cookiecutter.title}} Release Notes
+
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with --> 
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/RELEASE_NOTES.md
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/RELEASE_NOTES.md
@@ -1,0 +1,17 @@
+# {{cookiecutter.title}} Release Notes
+
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with --> 
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->


### PR DESCRIPTION
A top-level `RELEASE_NOTES.md` file is added, and a `.github/RELEASE_NOTES.template.md` template are added, as the template is already mentioned in the `CONTRIBUTING.md` guide.

Fixes #9.
