### PR TITLE
Don't import modules into packages and fix tests

### DIFF
--- a/cookiecutter/hooks/post_gen_project.py
+++ b/cookiecutter/hooks/post_gen_project.py
@@ -318,7 +318,8 @@ def print_todos() -> None:
     print()
     note(
         "Make sure to (create and) configure your GitHub repository too: "
-        "https://github.com/frequenz-floss/frequenz-repo-config-python/wiki/Configuring-a-new-GitHub-repository"
+        "https://github.com/frequenz-floss/frequenz-repo-config-python/"
+        "wiki/Configuring-a-new-GitHub-repository"
     )
 
 

--- a/cookiecutter/local_extensions.py
+++ b/cookiecutter/local_extensions.py
@@ -170,22 +170,16 @@ def default_codeowners(cookiecutter: dict[str, str]) -> str:
     if github_org != "frequenz-floss":
         return f"TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)"
 
-    match repo_type:
-        case "actor":
-            return (
-                "TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)"
-                "# Temporary, should probably change"
-            )
-        case "api":
-            return "@freqenz-floss/api-team"
-        case "lib":
-            return "@freqenz-floss/python-sdk-team"
-        case "app":
-            return (
-                "@freqenz-floss/python-sdk-team @frequenz-floss/datasci-team "
-                "# Temporary, should probably change"
-            )
-        case "model":
-            return "@freqenz-floss/datasci-team"
-        case _:
-            assert False, f"Unhandled repository type {repo_type!r}"
+    type_to_team = {
+        "actor": "TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)"
+        "# Temporary, should probably change",
+        "api": "@freqenz-floss/api-team",
+        "lib": "@freqenz-floss/python-sdk-team",
+        "app": "@freqenz-floss/python-sdk-team @frequenz-floss/datasci-team "
+        "# Temporary, should probably change",
+        "model": "@freqenz-floss/datasci-team",
+    }
+
+    assert repo_type in type_to_team, f"Unhandled repository type {repo_type!r}"
+
+    return type_to_team[repo_type]

--- a/cookiecutter/local_extensions.py
+++ b/cookiecutter/local_extensions.py
@@ -173,11 +173,11 @@ def default_codeowners(cookiecutter: dict[str, str]) -> str:
     type_to_team = {
         "actor": "TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)"
         "# Temporary, should probably change",
-        "api": "@freqenz-floss/api-team",
-        "lib": "@freqenz-floss/python-sdk-team",
-        "app": "@freqenz-floss/python-sdk-team @frequenz-floss/datasci-team "
+        "api": "@frequenz-floss/api-team",
+        "lib": "@frequenz-floss/python-sdk-team",
+        "app": "@frequenz-floss/python-sdk-team @frequenz-floss/datasci-team "
         "# Temporary, should probably change",
-        "model": "@freqenz-floss/datasci-team",
+        "model": "@frequenz-floss/datasci-team",
     }
 
     assert repo_type in type_to_team, f"Unhandled repository type {repo_type!r}"

--- a/cookiecutter/local_extensions.py
+++ b/cookiecutter/local_extensions.py
@@ -37,7 +37,7 @@ def _get_from_json(key: str) -> str:
         The string from the cookiecutter.json file.
     """
     with open("../cookiecutter.json", encoding="utf8") as cookiecutter_json_file:
-        return _json.load(cookiecutter_json_file)[key]
+        return str(_json.load(cookiecutter_json_file)[key])
 
 
 # Ignoring because cookiecutter simple_filter decorator is not typed.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/noxfile.py
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/noxfile.py
@@ -3,7 +3,6 @@
 
 """Configuration file for nox."""
 
-from frequenz.repo.config import nox
-from frequenz.repo.config.nox import default
+from frequenz.repo.config import RepositoryType, nox
 
-nox.configure(default.{{cookiecutter.type}}_config)
+nox.configure(RepositoryType.{{cookiecutter.type | upper}})

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/noxfile.py
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/noxfile.py
@@ -4,5 +4,6 @@
 """Configuration file for nox."""
 
 from frequenz.repo.config import nox
+from frequenz.repo.config.nox import default
 
-nox.configure(nox.default.{{cookiecutter.type}}_config)
+nox.configure(default.{{cookiecutter.type}}_config)

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,4 +13,4 @@ config.extra_paths.extend(
         "cookiecutter/local_extensions.py",
     ]
 )
-nox.configure(default.lib_config)
+nox.configure(config)

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,12 +4,13 @@
 """Configuration file for nox."""
 
 from frequenz.repo.config import nox
+from frequenz.repo.config.nox import default
 
-config = nox.default.lib_config.copy()
+config = default.lib_config.copy()
 config.extra_paths.extend(
     [
         "cookiecutter/hooks",
         "cookiecutter/local_extensions.py",
     ]
 )
-nox.configure(nox.default.lib_config)
+nox.configure(default.lib_config)

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -26,22 +26,22 @@ When writing the `noxfile.py` you should import the `nox` module from this
 package and use the [`frequenz.repo.config.nox.configure`][] function,
 which will configure all nox sessions.
 
-You should call `configure()` using one of the default configurations provided
-in the [`frequenz.repo.config.nox.default`][] module. For example:
+To use the default options, you should call `configure()` using one of the [repository
+types][frequenz.repo.config.RepositoryType].  For example:
 
 ```python
-from frequenz.repo.config import nox
-from frequenz.repo.config.nox import default
+from frequenz.repo.config import RepositoryType, nox
 
-nox.configure(default.lib_config)
+nox.configure(RepositoryType.LIB)
 ```
 
-Again, make sure to pick the correct default configuration based on the type of your
+Again, make sure to pick the correct project typedefault configuration based on the type of your
 project (`actor_config`, `api_config`, `app_config`, `lib_config`, `model_config`).
 
-If you need to modify the configuration, you can copy one of the default
-configurations by using the
-[`copy()`][frequenz.repo.config.nox.config.Config.copy] method:
+If you need to use some custom configuration, you can start from the default settings in
+the [`frequenz.repo.config.nox.default`][] module,
+[copying][frequenz.repo.config.nox.config.Config.copy] it and changing whatever you
+need to customize.  For example:
 
 ```python
 from frequenz.repo.config import nox

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -31,8 +31,9 @@ in the [`frequenz.repo.config.nox.default`][] module. For example:
 
 ```python
 from frequenz.repo.config import nox
+from frequenz.repo.config.nox import default
 
-nox.configure(nox.default.lib_config)
+nox.configure(default.lib_config)
 ```
 
 Again, make sure to pick the correct default configuration based on the type of your
@@ -44,8 +45,9 @@ configurations by using the
 
 ```python
 from frequenz.repo.config import nox
+from frequenz.repo.config.nox import default
 
-config = nox.default.lib_config.copy()
+config = default.lib_config.copy()
 config.opts.black.append("--diff")
 nox.configure(config)
 ```
@@ -330,12 +332,8 @@ Please adapt the instructions above to your project structure if you need to cha
 defaults.
 """
 
-from . import mkdocs, nox, setuptools
 from ._core import RepositoryType
 
 __all__ = [
     "RepositoryType",
-    "mkdocs",
-    "nox",
-    "setuptools",
 ]

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -5,7 +5,7 @@ r"""Frequenz project setup tools and common configuration.
 
 The tools are provided to configure the main types of repositories most commonly used at
 Frequenz, defined in
-[`freq.repo.config.RepositoryType`][freq.repo.config.RepositoryType].
+[`frequenz.repo.config.RepositoryType`][].
 
 - actor: SDK actors
 - api: gRPC APIs

--- a/src/frequenz/repo/config/nox/__init__.py
+++ b/src/frequenz/repo/config/nox/__init__.py
@@ -6,27 +6,30 @@
 The main entry point is the [`configure()`][configure] function, which will
 configure all nox sessions according to some configuration.
 
-You should call `configure()` using one of the default configurations provided
-in the [`default`][] module. For example:
+To use the default options, you should call `configure()` using one of the [repository
+types][frequenz.repo.config.RepositoryType].  For example:
 
 ```python
-from frequenz.repo.config import nox
-from frequenz.repo.config.nox import default
+from frequenz.repo.config import RepositoryType, nox
 
-nox.configure(default.lib_config)
+nox.configure(RepositoryType.LIB)
 ```
 
-If you need to modify the configuration, you can copy one of the default
-configurations by using the
-[`copy()`][frequenz.repo.config.nox.config.Config.copy] method:
+Again, make sure to pick the correct project typedefault configuration based on the type of your
+project (`actor_config`, `api_config`, `app_config`, `lib_config`, `model_config`).
+
+If you need to use some custom configuration, you can start from the default settings in
+the [`frequenz.repo.config.nox.default`][] module,
+[copying][frequenz.repo.config.nox.config.Config.copy] it and changing whatever you
+need to customize.  For example:
 
 ```python
 from frequenz.repo.config import nox
 from frequenz.repo.config.nox import default
 
-conf = default.lib_config.copy()
-conf.opts.black.append("--diff")
-nox.configure(conf)
+config = default.lib_config.copy()
+config.opts.black.append("--diff")
+nox.configure(config)
 ```
 
 If you need further customization or to define new sessions, you can use the

--- a/src/frequenz/repo/config/nox/__init__.py
+++ b/src/frequenz/repo/config/nox/__init__.py
@@ -10,9 +10,10 @@ You should call `configure()` using one of the default configurations provided
 in the [`default`][] module. For example:
 
 ```python
-from frequenz.repo import config
+from frequenz.repo.config import nox
+from frequenz.repo.config.nox import default
 
-config.nox.configure(config.nox.default.lib_config)
+nox.configure(default.lib_config)
 ```
 
 If you need to modify the configuration, you can copy one of the default
@@ -20,11 +21,12 @@ configurations by using the
 [`copy()`][frequenz.repo.config.nox.config.Config.copy] method:
 
 ```python
-from frequenz.repo import config
+from frequenz.repo.config import nox
+from frequenz.repo.config.nox import default
 
-conf = config.nox.default.lib_config.copy()
+conf = default.lib_config.copy()
 conf.opts.black.append("--diff")
-config.nox.configure(conf)
+nox.configure(conf)
 ```
 
 If you need further customization or to define new sessions, you can use the
@@ -41,13 +43,8 @@ following modules:
 - [`util`][]: General purpose utility functions.
 """
 
-from . import config, default, session, util
 from .config import configure
 
 __all__ = [
-    "config",
     "configure",
-    "default",
-    "session",
-    "util",
 ]

--- a/src/frequenz/repo/config/nox/config.py
+++ b/src/frequenz/repo/config/nox/config.py
@@ -14,10 +14,11 @@ The `configure()` function must be called before `get()` is used.
 
 import dataclasses as _dataclasses
 import itertools as _itertools
-from typing import Self
+from typing import Self, assert_never, overload
 
 import nox as _nox
 
+from .._core import RepositoryType
 from . import util as _util
 
 
@@ -177,6 +178,7 @@ def get() -> Config:
     return _config
 
 
+@overload
 def configure(conf: Config, /, *, import_default_sessions: bool = True) -> None:
     """Configure nox using the provided configuration.
 
@@ -186,10 +188,63 @@ def configure(conf: Config, /, *, import_default_sessions: bool = True) -> None:
             This is only necessary if you want to avoid using the default provided
             sessions and use your own.
     """
+
+
+@overload
+def configure(
+    repo_type: RepositoryType, /, *, import_default_sessions: bool = True
+) -> None:
+    """Configure nox using the provided repository type.
+
+    Args:
+        repo_type: The repository type to use to configure nox.  This will use the
+            default configuration in [`frequenz.repo.config.nox.default`][] for that
+            type of repository.
+        import_default_sessions: Whether to import the default sessions or not.
+            This is only necessary if you want to avoid using the default provided
+            sessions and use your own.
+    """
+
+
+def configure(
+    conf: Config | RepositoryType, /, *, import_default_sessions: bool = True
+) -> None:
+    """Configure nox using the provided configuration or repository type.
+
+    Args:
+        conf: The configuration to use to configure nox, or the repository type to use
+            to configure nox.  The later will use the default configuration in
+            [`frequenz.repo.config.nox.default`][] for that type of repository.
+        import_default_sessions: Whether to import the default sessions or not.
+            This is only necessary if you want to avoid using the default provided
+            sessions and use your own.
+    """
+    global _config  # pylint: disable=global-statement
+
     # We need to make sure sessions are imported, otherwise they won't be visible to nox.
     if import_default_sessions:
         # pylint: disable=import-outside-toplevel,cyclic-import
         from . import session as _
-    global _config  # pylint: disable=global-statement
-    _config = conf
+
+    match conf:
+        case Config():
+            _config = conf
+        case RepositoryType() as repo_type:
+            # pylint: disable=import-outside-toplevel,cyclic-import
+            from . import default
+
+            match repo_type:
+                case RepositoryType.ACTOR:
+                    _config = default.actor_config
+                case RepositoryType.API:
+                    _config = default.api_config
+                case RepositoryType.APP:
+                    _config = default.app_config
+                case RepositoryType.LIB:
+                    _config = default.lib_config
+                case RepositoryType.MODEL:
+                    _config = default.model_config
+                case _ as unhandled:
+                    assert_never(unhandled)
+
     _nox.options.sessions = _config.sessions

--- a/src/frequenz/repo/config/nox/config.py
+++ b/src/frequenz/repo/config/nox/config.py
@@ -177,12 +177,19 @@ def get() -> Config:
     return _config
 
 
-def configure(conf: Config, /) -> None:
+def configure(conf: Config, /, *, import_default_sessions: bool = True) -> None:
     """Configure nox using the provided configuration.
 
     Args:
         conf: The configuration to use to configure nox.
+        import_default_sessions: Whether to import the default sessions or not.
+            This is only necessary if you want to avoid using the default provided
+            sessions and use your own.
     """
+    # We need to make sure sessions are imported, otherwise they won't be visible to nox.
+    if import_default_sessions:
+        # pylint: disable=import-outside-toplevel,cyclic-import
+        from . import session as _
     global _config  # pylint: disable=global-statement
     _config = conf
     _nox.options.sessions = _config.sessions

--- a/src/frequenz/repo/config/setuptools/__init__.py
+++ b/src/frequenz/repo/config/setuptools/__init__.py
@@ -2,9 +2,3 @@
 # Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Setuptools utilities."""
-
-from . import grpc_tools
-
-__all__ = [
-    "grpc_tools",
-]


### PR DESCRIPTION
- Fix wrong documentation reference
- Use a dict to map repo types to owners
- Split too long line
- Return proper type in cookiecutter local extensions
- Install the local development version in integration tests
- Don't import modules into packages
- Import default nox sessions by default
- Fix passing of nox config
- Add a `nox.configure()` overload that takes a `RepositoryType`
- Fix typos in GitHub teams

Fixes #46.
