### PR TITLE
Fix issues in CI and updating projects

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         # To speed things up a bit we use the speciall ci_checks_max session
         # that uses the same venv to run multiple linting sessions
         run: nox -e ci_checks_max pytest_min
-        timeout-minutes: 10
+        timeout-minutes: 60
 
   build:
     name: Build distribution packages

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    needs: ["test", "build"]
+    needs: ["nox", "build"]
     if: github.event_name == 'push'
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-${{ env.DEFAULT_UBUNTU_VERSION }}
+    runs-on: ubuntu-20.04
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
@@ -123,7 +123,7 @@ jobs:
     name: Publish documentation website to GitHub pages
     needs: ["test", "build"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-${{ env.DEFAULT_UBUNTU_VERSION }}
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
     steps:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ the files in your existing project by using `rsync` or similar tools:
 ```sh
 cd /tmp
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python --directory=cookiecutter
-rsync -r new-project/ /path/to/existing/project
+rsync -vr --exclude=.git/ new-project/ /path/to/existing/project
 cd /path/to/existing/project
 git diff
 # Fix all the `TODO`s and cleanup the generated files
@@ -82,6 +82,9 @@ git commit -a
 
     The trailing slash in `new-project/` and the lack of it in
     `/path/to/existing/project` are meaningful to `rsync`.
+
+    Also make sure to **exclude** the `.git/` directory to avoid messing up
+    with your local git repository.
 
 ## Update an existing project
 

--- a/cookiecutter/hooks/post_gen_project.py
+++ b/cookiecutter/hooks/post_gen_project.py
@@ -381,12 +381,8 @@ def finish_api_setup() -> None:
     * Rename `src` to `py`
     * Rename `tests` to `pytests`
     """
-    # We can't do a simple rename because the target directory might not be empty if
-    # overwriting an existing project.
-    _shutil.copytree("src", "py", dirs_exist_ok=True)
-    _shutil.rmtree("src")
-    _shutil.copytree("tests", "pytests", dirs_exist_ok=True)
-    _shutil.rmtree("tests")
+    recursive_overwrite_move(_pathlib.Path("src"), _pathlib.Path("py"))
+    recursive_overwrite_move(_pathlib.Path("tests"), _pathlib.Path("pytests"))
 
 
 def finish_app_setup() -> None:
@@ -469,6 +465,19 @@ def try_run(
         note(note_on_failure)
 
     return result
+
+
+def recursive_overwrite_move(src: _pathlib.Path, dst: _pathlib.Path) -> None:
+    """Recursively move a directory overwriting the target files if they exist.
+
+    Useful when overwriting an existing project to update it.
+
+    Args:
+        src: The source directory.
+        dst: The target directory.
+    """
+    _shutil.copytree(src, dst, dirs_exist_ok=True)
+    _shutil.rmtree(src)
 
 
 def success(message: str) -> None:

--- a/cookiecutter/hooks/post_gen_project.py
+++ b/cookiecutter/hooks/post_gen_project.py
@@ -406,8 +406,9 @@ def finish_lib_setup() -> None:
       - `lib`: `src/frequenz/{name}`
       - `rest`: `src/frequenz/{type}/{name}`
     """
-    _pathlib.Path(f"src/frequenz/{cookiecutter.type}/{cookiecutter.name}").rename(
-        f"src/frequenz/{cookiecutter.name}"
+    recursive_overwrite_move(
+        _pathlib.Path(f"src/frequenz/{cookiecutter.type}/{cookiecutter.name}"),
+        _pathlib.Path(f"src/frequenz/{cookiecutter.name}"),
     )
     _pathlib.Path(f"src/frequenz/{cookiecutter.type}").rmdir()
 

--- a/cookiecutter/hooks/post_gen_project.py
+++ b/cookiecutter/hooks/post_gen_project.py
@@ -116,6 +116,11 @@ def copy_replay_file() -> None:
     """Copy the replay file to the project root."""
     src = _pathlib.Path("~/.cookiecutter_replay/cookiecutter.json").expanduser()
     dst = _pathlib.Path(".cookiecutter-replay.json")
+
+    if dst.exists():
+        print(f"Replay file {dst} already exists. Skipping...")
+        return
+
     if not src.exists():
         print(f"WARNING: No replay file found in {src}. Skipping...")
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    needs: ["test", "build"]
+    needs: ["nox", "build"]
     if: github.event_name == 'push'
     runs-on: ubuntu-20.04
     permissions:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-{{'${{ env.DEFAULT_UBUNTU_VERSION }}'}}
+    runs-on: ubuntu-20.04
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
@@ -123,7 +123,7 @@ jobs:
     name: Publish documentation website to GitHub pages
     needs: ["test", "build"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-{{'${{ env.DEFAULT_UBUNTU_VERSION }}'}}
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
- Don't copy the replay file if it already exists
- Add function to recursively move files overwriting the target
- Fix updating `lib` projects
- Fix CI mkdocs related jobs not to use `env`
- Improve the suggested `rsync` command for updates
