### PR TITLE
Fix and improve documentation and generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Frequenz repository common configuration for Python
+# Frequenz repository configuration for Python
 
 [![Build Status](https://github.com/frequenz-floss/frequenz-repo-config-python/actions/workflows/ci.yaml/badge.svg)](https://github.com/frequenz-floss/frequenz-repo-config-python/actions/workflows/ci.yaml)
 [![PyPI Package](https://img.shields.io/pypi/v/frequenz-repo-config)](https://pypi.org/project/frequenz-repo-config/)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Frequenz repository common configuration for Python
 
 This is very opinionated set of tools and configurations to setup a Python
-repository for Frequenz projects.
+repository for [Frequenz](https://frequenz.com) projects.
 
 If offers:
 

--- a/README.md
+++ b/README.md
@@ -43,20 +43,93 @@ cookiecutter gh:frequenz-floss/frequenz-repo-config-python --directory=cookiecut
 This will prompt for the project type, name and other configuration and
 generate the whole project for you.
 
-After completing it and fixing the TODOs
-you can amend the previous commit using `git commit --amend`
-or create a new commit for the changes using `git commit`.
-You can make sure linting and tests pass by creating a virtual
-environment, installing the development dependencies and running `nox`:
+After completing it and fixing the `TODO`s you can amend the previous commit
+using `git commit --amend` or create a new commit for the changes using `git
+commit`.
+
+### Create the local development environment
+
+To start the development, you need to make sure your environment is correctly
+setup. One way to do this is by using a virtual environment and installing all
+the dependencies there:
+
 ```sh
 # requires at least python version 3.11
 python3 -m venv .venv
 . .venv/bin/activate
-pip install .[dev-noxfile]
-nox
+pip install -e .[dev]
 ```
 
-## Migrating an existing project
+This will install you package in [*editable*
+mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html), so
+you can open a python interpreter and import your package modules and pick up
+any local changes without the need to reinstall.  You can now run tools
+directly, like `pytest`.
+
+### Verify the new repository is healthy using `nox`
+
+If you prefer to keep your virtual enviroment cleaner and avoid installing development dependencies, you can also use `nox` to create isolated environments for you:
+
+```sh
+pip install -e .[dev-noxfile]
+nox --install-only  # Set up virtual environments once
+nox -R  # Run linting and testing reusing the already existing virtual environments
+```
+
+This will only install you package in *editable* mode and the minimum
+dependencies to be able to run `nox`, and then run all `nox` default sessions,
+which will run linters and tests.
+
+!!! note
+
+    It's much faster to use `nox` with `--install-only` once (each time to
+    change or update dependencies you need to run it again) and then using `nox
+    -R` to run the sessions without re-creating the virtual environments.
+
+    Otherwise `nox` will create many virtual environments each time you run it,
+    which is **very** slow.
+
+### Verify the generated documentation works
+
+To generate the documentation you can use `mkdocs`:
+
+```sh
+pip install .[dev-mkdocs]  # Not necessary if you already installed .[dev]
+mkdocs serve
+```
+
+If the command fails, look at the log warnings and errors and fix them.  If it
+worked, now there is a local web server serving the documentation, you can
+point your browser to Now you can point your browser to
+[http://127.0.0.1:8000](/http://127.0.0.1:8000/) to have a look.
+
+!!! info
+
+    For API projects `docker` is needed to generate and serve documentation, as
+    the easiest way to use the [tool to generate the documentation from
+    `.proto`](https://github.com/pseudomuto/protoc-gen-doc) files is using
+    `docker`.
+
+### Initialize the GitHub pages website
+
+The generated documentation can be easily published via GitHub pages, and it
+will be automatically updated for new pushed and releases, but for that to work
+correctly, some initial setup is needed:
+
+```sh
+pip install -e .[dev-mkdocs]  # Not necessary if you already installed .[dev]
+mike deploy --update-aliases next latest  # Creates the branch gh-pages locally
+mike set-default latest  # Makes the latest alias the default version
+git push upstream gh-pages  # Pushes the new branch upstream so the website is published
+```
+
+Then make sure that GitHub pages is enabled in
+`https://github.com/<repo-owner>/<repo-name>/settings/pages`.
+
+If all went well, your website should be available soon via
+`https://<repo-owner>.github.io//<repo-name>/`.
+
+## Migrate an existing project
 
 The easiest way to migrate an existing project is to just generate a new one
 basing all the inputs in the current project metadata and then overwritting the
@@ -85,6 +158,12 @@ git commit -a
 
     Also make sure to **exclude** the `.git/` directory to avoid messing up
     with your local git repository.
+
+!!! tip
+
+    Please have a look at the follow-up steps listed in the [Start a new
+    project](#create-the-local-development-environment) section to finish the
+    setup.
 
 ## Update an existing project
 
@@ -128,6 +207,12 @@ templates update commit.
 
     Please remember to keep your replay file up to date if you change any
     metadata in the project.
+
+!!! tip
+
+    Please have a look at the follow-up steps listed in the [Start a new
+    project](#create-the-local-development-environment) section to finish the
+    setup.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,18 @@ templates update commit.
     project](#create-the-local-development-environment) section to finish the
     setup.
 
+## Advanced usage
+
+The Cookiecutter template uses some tools provided as a library by this
+project.
+
+Usually users don't need deal with it directly, but if you project needs some
+extra customization (like disabling `nox` sessions or adding new ones, or using
+different CLI options for some tools), then you'll need to.
+
+You can find information about the extra features in the [API
+refence](reference/frequenz/repo/config/).
+
 ## Contributing
 
 If you want to know how to build this project and contribute to it, please

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Frequenz repository common configuration for Python
 
+## Introduction
+
 This is very opinionated set of tools and configurations to setup a Python
 repository for [Frequenz](https://frequenz.com) projects.
 
@@ -13,7 +15,9 @@ If offers:
 
 [Cookiecutter]: https://cookiecutter.readthedocs.io/en/stable
 
-## Start a new project
+## Usage
+
+### Start a new project
 
 To start a new project you should first [install
 Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/installation.html).
@@ -47,7 +51,7 @@ After completing it and fixing the `TODO`s you can amend the previous commit
 using `git commit --amend` or create a new commit for the changes using `git
 commit`.
 
-### Create the local development environment
+#### Create the local development environment
 
 To start the development, you need to make sure your environment is correctly
 setup. One way to do this is by using a virtual environment and installing all
@@ -66,7 +70,7 @@ you can open a python interpreter and import your package modules and pick up
 any local changes without the need to reinstall.  You can now run tools
 directly, like `pytest`.
 
-### Verify the new repository is healthy using `nox`
+#### Verify the new repository is healthy using `nox`
 
 If you prefer to keep your virtual enviroment cleaner and avoid installing development dependencies, you can also use `nox` to create isolated environments for you:
 
@@ -89,7 +93,7 @@ which will run linters and tests.
     Otherwise `nox` will create many virtual environments each time you run it,
     which is **very** slow.
 
-### Verify the generated documentation works
+#### Verify the generated documentation works
 
 To generate the documentation you can use `mkdocs`:
 
@@ -110,7 +114,7 @@ point your browser to Now you can point your browser to
     `.proto`](https://github.com/pseudomuto/protoc-gen-doc) files is using
     `docker`.
 
-### Initialize the GitHub pages website
+#### Initialize the GitHub pages website
 
 The generated documentation can be easily published via GitHub pages, and it
 will be automatically updated for new pushed and releases, but for that to work
@@ -129,7 +133,7 @@ Then make sure that GitHub pages is enabled in
 If all went well, your website should be available soon via
 `https://<repo-owner>.github.io//<repo-name>/`.
 
-## Migrate an existing project
+### Migrate an existing project
 
 The easiest way to migrate an existing project is to just generate a new one
 basing all the inputs in the current project metadata and then overwritting the
@@ -165,7 +169,7 @@ git commit -a
     project](#create-the-local-development-environment) section to finish the
     setup.
 
-## Update an existing project
+### Update an existing project
 
 To update an existing project you can use the [Cookiecutter *replay
 file*](https://cookiecutter.readthedocs.io/en/stable/advanced/replay.html) that

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Frequenz repository common configuration for Python
 
+[![Build Status](https://github.com/frequenz-floss/frequenz-repo-config-python/actions/workflows/ci.yaml/badge.svg)](https://github.com/frequenz-floss/frequenz-repo-config-python/actions/workflows/ci.yaml)
+[![PyPI Package](https://img.shields.io/pypi/v/frequenz-repo-config)](https://pypi.org/project/frequenz-repo-config/)
+[![Docs](https://img.shields.io/badge/docs-latest-informational)](https://frequenz-floss.github.io/frequenz-repo-config-python/)
+
 ## Introduction
 
 This is very opinionated set of tools and configurations to setup a Python

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Frequenz repository configuration for Python
+# Frequenz Repository Configuration
 
 [![Build Status](https://github.com/frequenz-floss/frequenz-repo-config-python/actions/workflows/ci.yaml/badge.svg)](https://github.com/frequenz-floss/frequenz-repo-config-python/actions/workflows/ci.yaml)
 [![PyPI Package](https://img.shields.io/pypi/v/frequenz-repo-config)](https://pypi.org/project/frequenz-repo-config/)
@@ -6,36 +6,36 @@
 
 ## Introduction
 
-This is very opinionated set of tools and configurations to setup a Python
+This is a highly opinionated set of tools and configurations to set up a Python
 repository for [Frequenz](https://frequenz.com) projects.
 
-If offers:
+It offers:
 
 * [Cookiecutter] templates for scaffolding new projects
-* Trivial build of `noxfile.py` with some predefined sessions with all common
-  checks.
+* Trivial build of `noxfile.py` with some predefined sessions that include all
+  common checks.
 * Tools to build protobuf/grpc files as Python, including type information.
 
 ## Quick Example
 
-To start a new project you should first [install
+To start a new project, you should first [install
 Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/installation.html).
 It is normally available in any Linux distribution, but some have a very old
-version (for example, Ubuntu/Debian).  You can [check which version your distro
-has in Repology](https://repology.org/project/cookiecutter/versions). You need
-**at least version 2.1.0**.  To make sure to get an up to date version you can
-always uses `pip` and install in a `venv`:
+version (for example, Ubuntu/Debian). You can [check which version your distro
+has on Repology](https://repology.org/project/cookiecutter/versions). You need
+**at least version 2.1.0**. To ensure you get an up-to-date version, you can
+always use `pip` and install it in a `venv`:
 
 ```console
 $ python -m venv cookiecutter
 $ cd cookiecutter
 $ . bin/activate
-[cookiecutter] $ pip install cookiecutter
+(venv) $ pip install cookiecutter
 Collecting cookiecutter
 ...
 ```
 
-Then just run cookiecutter where you want to create the new project. A new
+Then simply run [Cookiecutter] where you want to create the new project. A new
 directory will be created with the generated project name. For example:
 
 ```sh
@@ -43,22 +43,22 @@ cd ~/devel
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python --directory=cookiecutter
 ```
 
-This will prompt for the project type, name and other configuration and
-generate the whole project for you.
+This command will prompt you for the project type, name, and other
+configuration options, and it will generate the entire project for you.
 
-After completing it and fixing the `TODO`s you can amend the previous commit
-using `git commit --amend` or create a new commit for the changes using `git
-commit`.
+After completing the project and fixing the `TODO`s, you can either amend the
+previous commit using `git commit --amend` or create a new commit for the
+changes using `git commit`.
 
 ## Documentation
 
-For more detailed documentation please check the [project's
+For more detailed documentation, please check the [project's
 website](https://frequenz-floss.github.io/frequenz-repo-config-python/).
 
 ## Contributing
 
 If you want to know how to build this project and contribute to it, please
-check out the [Contributing Guide](CONTRIBUTING.md).
+refer to the [Contributing Guide](CONTRIBUTING.md).
 
 
 [Cookiecutter]: https://cookiecutter.readthedocs.io/en/stable

--- a/README.md
+++ b/README.md
@@ -12,12 +12,7 @@ If offers:
   checks.
 * Tools to build protobuf/grpc files as Python, including type information.
 
-
-[Cookiecutter]: https://cookiecutter.readthedocs.io/en/stable
-
-## Usage
-
-### Start a new project
+## Quick Example
 
 To start a new project you should first [install
 Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/installation.html).
@@ -51,186 +46,15 @@ After completing it and fixing the `TODO`s you can amend the previous commit
 using `git commit --amend` or create a new commit for the changes using `git
 commit`.
 
-#### Create the local development environment
+## Documentation
 
-To start the development, you need to make sure your environment is correctly
-setup. One way to do this is by using a virtual environment and installing all
-the dependencies there:
-
-```sh
-# requires at least python version 3.11
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -e .[dev]
-```
-
-This will install you package in [*editable*
-mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html), so
-you can open a python interpreter and import your package modules and pick up
-any local changes without the need to reinstall.  You can now run tools
-directly, like `pytest`.
-
-#### Verify the new repository is healthy using `nox`
-
-If you prefer to keep your virtual enviroment cleaner and avoid installing development dependencies, you can also use `nox` to create isolated environments for you:
-
-```sh
-pip install -e .[dev-noxfile]
-nox --install-only  # Set up virtual environments once
-nox -R  # Run linting and testing reusing the already existing virtual environments
-```
-
-This will only install you package in *editable* mode and the minimum
-dependencies to be able to run `nox`, and then run all `nox` default sessions,
-which will run linters and tests.
-
-!!! note
-
-    It's much faster to use `nox` with `--install-only` once (each time to
-    change or update dependencies you need to run it again) and then using `nox
-    -R` to run the sessions without re-creating the virtual environments.
-
-    Otherwise `nox` will create many virtual environments each time you run it,
-    which is **very** slow.
-
-#### Verify the generated documentation works
-
-To generate the documentation you can use `mkdocs`:
-
-```sh
-pip install .[dev-mkdocs]  # Not necessary if you already installed .[dev]
-mkdocs serve
-```
-
-If the command fails, look at the log warnings and errors and fix them.  If it
-worked, now there is a local web server serving the documentation, you can
-point your browser to Now you can point your browser to
-[http://127.0.0.1:8000](/http://127.0.0.1:8000/) to have a look.
-
-!!! info
-
-    For API projects `docker` is needed to generate and serve documentation, as
-    the easiest way to use the [tool to generate the documentation from
-    `.proto`](https://github.com/pseudomuto/protoc-gen-doc) files is using
-    `docker`.
-
-#### Initialize the GitHub pages website
-
-The generated documentation can be easily published via GitHub pages, and it
-will be automatically updated for new pushed and releases, but for that to work
-correctly, some initial setup is needed:
-
-```sh
-pip install -e .[dev-mkdocs]  # Not necessary if you already installed .[dev]
-mike deploy --update-aliases next latest  # Creates the branch gh-pages locally
-mike set-default latest  # Makes the latest alias the default version
-git push upstream gh-pages  # Pushes the new branch upstream so the website is published
-```
-
-Then make sure that GitHub pages is enabled in
-`https://github.com/<repo-owner>/<repo-name>/settings/pages`.
-
-If all went well, your website should be available soon via
-`https://<repo-owner>.github.io//<repo-name>/`.
-
-### Migrate an existing project
-
-The easiest way to migrate an existing project is to just generate a new one
-basing all the inputs in the current project metadata and then overwritting the
-existing files.
-
-It is recommended to commit all changes before doing this, so you can then use
-`git` to look at the changes.
-
-If you generate the new repo in a temporary directory, you can easily overwrite
-the files in your existing project by using `rsync` or similar tools:
-
-```sh
-cd /tmp
-cookiecutter gh:frequenz-floss/frequenz-repo-config-python --directory=cookiecutter
-rsync -vr --exclude=.git/ new-project/ /path/to/existing/project
-cd /path/to/existing/project
-git diff
-# Fix all the `TODO`s and cleanup the generated files
-git commit -a
-```
-
-!!! warning
-
-    The trailing slash in `new-project/` and the lack of it in
-    `/path/to/existing/project` are meaningful to `rsync`.
-
-    Also make sure to **exclude** the `.git/` directory to avoid messing up
-    with your local git repository.
-
-!!! tip
-
-    Please have a look at the follow-up steps listed in the [Start a new
-    project](#create-the-local-development-environment) section to finish the
-    setup.
-
-### Update an existing project
-
-To update an existing project you can use the [Cookiecutter *replay
-file*](https://cookiecutter.readthedocs.io/en/stable/advanced/replay.html) that
-was saved during the project generation.  The file is saved in
-`.cookiecutter-replay.json`.  Using this file you can re-run Cookiecutter
-without having to enter all the inputs again.
-
-!!! warning
-
-    Don't forget to commit all changes in your repository before doing this!
-    Files will be overwritten!
-
-```sh
-git commit -a  # commit all changes
-cd ..
-cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
-    --directory=cookiecutter \
-    --force \
-    --replay \
-    --replay-file project-directory/.cookiecutter-replay.json
-```
-
-This will create a new commit with all the changes to the overwritten files.
-Bear in mind that all the `TODO`s will come back, so there will be quite a bit
-of cleanup to do.  You can easily check what was changed using `git show`, and
-you can use `git commit --amend` to amend the previous commit with the template
-updates, or create a new commit with the fixes.  You can also use `git citool`
-or `git gui` to easily add, remove or even discard (revert) changes in the
-templates update commit.
-
-!!! note
-
-    The `project-directory` is the directory of your previously generated
-    project. If you renamed it, then the files will be generated in a new
-    directory with the original name.  You can update the target directory in
-    the replay file.
-
-!!! note
-
-    Please remember to keep your replay file up to date if you change any
-    metadata in the project.
-
-!!! tip
-
-    Please have a look at the follow-up steps listed in the [Start a new
-    project](#create-the-local-development-environment) section to finish the
-    setup.
-
-## Advanced usage
-
-The Cookiecutter template uses some tools provided as a library by this
-project.
-
-Usually users don't need deal with it directly, but if you project needs some
-extra customization (like disabling `nox` sessions or adding new ones, or using
-different CLI options for some tools), then you'll need to.
-
-You can find information about the extra features in the [API
-refence](reference/frequenz/repo/config/).
+For more detailed documentation please check the [project's
+website](https://frequenz-floss.github.io/frequenz-repo-config-python/).
 
 ## Contributing
 
 If you want to know how to build this project and contribute to it, please
 check out the [Contributing Guide](CONTRIBUTING.md).
+
+
+[Cookiecutter]: https://cookiecutter.readthedocs.io/en/stable

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,9 +6,9 @@ This release is a major step and adds many features and breaking changes.
 
 ## Upgrading
 
-Since this projects is still in very heavy devepoment, the easiest way to
-upgrade is to just regenerate the templates.  Please follow the instructions in
-the new documentation website about [updating
+Since this project is still in heavy development, the easiest way to upgrade is
+to regenerate the templates. Please follow the instructions in the new
+documentation website about [updating
 projects](https://frequenz-floss.github.io/frequenz-repo-config-python/next/#update-an-existing-project).
 
 ## New Features
@@ -22,7 +22,7 @@ This is just a quick (non-comprehensive) summary of the new features:
 * Cookiecutter template
 
   * Add `dependabot` configuration
-  * Add issue templates, keyword labeler and PR labeler
+  * Add issue templates, keyword labeler, and PR labeler
   * Add `CODEOWNERS` file
   * Add `direnv`-related files to `.gitignore`
   * Add GitHub CI workflow to `cookiecutter`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,39 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This release is a major step and adds many features and breaking changes.
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with --> 
+Since this projects is still in very heavy devepoment, the easiest way to
+upgrade is to just regenerate the templates.  Please follow the instructions in
+the new documentation website about [updating
+projects](https://frequenz-floss.github.io/frequenz-repo-config-python/next/#update-an-existing-project).
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+This is just a quick (non-comprehensive) summary of the new features:
+
+* Add `--diff` as a default argument for `isort`
+* Improve `README`
+* Don't import modules into packages
+* Support migrating and updating existing projects with Cookiecutter
+* Cookiecutter template
+
+  * Add `dependabot` configuration
+  * Add issue templates, keyword labeler and PR labeler
+  * Add `CODEOWNERS` file
+  * Add `direnv`-related files to `.gitignore`
+  * Add GitHub CI workflow to `cookiecutter`
+  * Add `CONTRIBUTING` guide to `cookiecutter`
+  * Add `RELEASE_NOTES` to `cookiecutter`
+  * Add support to generate documentation using `mkdocs`
+
+* Apply all the Cookiecutter template improvements to this project
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+This is just a quick (non-comprehensive) summary of bug fixes:
+
+* Fix some comments about creating labels
+* Fix tests

--- a/cookiecutter/hooks/post_gen_project.py
+++ b/cookiecutter/hooks/post_gen_project.py
@@ -66,11 +66,27 @@ def main() -> None:
     print(". .venv/bin/activate")
     print("pip install .[dev-noxfile]")
     print("nox")
-    print("# To generate and serve the documentation:")
+    print()
+    print("To generate and serve the documentation:")
     print("pip install .[dev-mkdocs]")
     if cookiecutter.type == "api":
         print("# Requires docker")
     print("mkdocs serve")
+    print()
+    print("To initialize the GitHub pages website:")
+    print("mike deploy --update-aliases next latest")
+    print("mike set-default latest")
+    print("git push upstream gh-pages  # or origin if you haven't forked the repo")
+    print()
+    print("Make sure that GitHub pages is enabled in your repository settings:")
+    print(
+        f"https://github.com/{cookiecutter.github_org}/{cookiecutter.github_repo_name}"
+        "/settings/pages"
+    )
+    print("If all went well, your new website should be available soon at:")
+    print(
+        f"https://{cookiecutter.github_org}.github.io/{cookiecutter.github_repo_name}/"
+    )
     print()
     if warnings := do_sanity_checks():
         for warning in warnings:
@@ -80,7 +96,9 @@ def main() -> None:
         "If you had any issues or find any errors in the generated files, "
         "please report them!"
     )
-    note("https://github.com/frequenz-floss/frequenz-repo-config-python/issues/new")
+    note(
+        "https://github.com/frequenz-floss/frequenz-repo-config-python/issues/new/choose"
+    )
     print()
 
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/README.md
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/README.md
@@ -1,5 +1,11 @@
 # {{cookiecutter.title}}
 
+[![Build Status](https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.github_repo_name}}/actions/workflows/ci.yaml/badge.svg)](https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.github_repo_name}}/actions/workflows/ci.yaml)
+[![PyPI Package](https://img.shields.io/pypi/v/{{cookiecutter.pypi_package_name}})](https://pypi.org/project/{{cookiecutter.pypi_package_name}}/)
+[![Docs](https://img.shields.io/badge/docs-latest-informational)](https://{{cookiecutter.github_org}}.github.io/{{cookiecutter.github_repo_name}}/)
+
+## Introduction
+
 {{cookiecutter.description}}
 
 TODO(cookiecutter): Improve the README file

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -11,6 +11,7 @@ repo_url: "https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.github_
 # TODO(cookiecutter): "main" is the GitHub repo default branch, you might want to update it
 # if the project uses a different default branch.
 edit_uri: "edit/main/docs/"
+strict: true  # Treat warnings as errors
 
 # Build directories
 theme:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,26 @@
-# Frequenz repository configuration for Python
+# Frequenz Repository Configuration
 
 ## Introduction
 
-This is very opinionated set of tools and configurations to setup a Python
+This is a highly opinionated set of tools and configurations to set up a Python
 repository for [Frequenz](https://frequenz.com) projects.
 
-If offers:
+It offers:
 
 * [Cookiecutter] templates for scaffolding new projects
-* Trivial build of `noxfile.py` with some predefined sessions with all common
-  checks.
+* Trivial build of `noxfile.py` with some predefined sessions that include all
+  common checks.
 * Tools to build protobuf/grpc files as Python, including type information.
 
 ## Start a new project
 
-To start a new project you should first [install
+To start a new project, you should first [install
 Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/installation.html).
 It is normally available in any Linux distribution, but some have a very old
-version (for example, Ubuntu/Debian).  You can [check which version your distro
-has in Repology](https://repology.org/project/cookiecutter/versions). You need
-**at least version 2.1.0**.  To make sure to get an up to date version you can
-always uses `pip` and install in a `venv`:
+version (for example, Ubuntu/Debian). You can [check which version your distro
+has on Repology](https://repology.org/project/cookiecutter/versions). You need
+**at least version 2.1.0**. To ensure you get an up-to-date version, you can
+always use `pip` and install it in a `venv`:
 
 ```console
 $ python -m venv cookiecutter
@@ -31,7 +31,7 @@ Collecting cookiecutter
 ...
 ```
 
-Then just run cookiecutter where you want to create the new project. A new
+Then simply run [Cookiecutter] where you want to create the new project. A new
 directory will be created with the generated project name. For example:
 
 ```sh
@@ -39,100 +39,101 @@ cd ~/devel
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python --directory=cookiecutter
 ```
 
-This will prompt for the project type, name and other configuration and
-generate the whole project for you.
+This command will prompt you for the project type, name, and other
+configuration options, and it will generate the entire project for you.
 
-After completing it and fixing the `TODO`s you can amend the previous commit
-using `git commit --amend` or create a new commit for the changes using `git
-commit`.
+After completing the project and fixing the `TODO`s, you can either amend the
+previous commit using `git commit --amend` or create a new commit for the
+changes using `git commit`.
 
 ### Create the local development environment
 
-To start the development, you need to make sure your environment is correctly
-setup. One way to do this is by using a virtual environment and installing all
-the dependencies there:
+To start development, you need to make sure your environment is correctly set
+up. One way to do this is by using a virtual environment and installing all the
+dependencies there:
 
 ```sh
-# requires at least python version 3.11
+# requires at least Python version 3.11
 python3 -m venv .venv
 . .venv/bin/activate
 pip install -e .[dev]
 ```
 
-This will install you package in [*editable*
+This will install your package in [*editable*
 mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html), so
-you can open a python interpreter and import your package modules and pick up
-any local changes without the need to reinstall.  You can now run tools
+you can open a Python interpreter and import your package modules, picking up
+any local changes without the need to reinstall. Now you can run tools
 directly, like `pytest`.
 
 ### Verify the new repository is healthy using `nox`
 
-If you prefer to keep your virtual enviroment cleaner and avoid installing development dependencies, you can also use `nox` to create isolated environments for you:
+If you prefer to keep your virtual environment cleaner and avoid installing
+development dependencies, you can also use `nox` to create isolated
+environments:
 
 ```sh
 pip install -e .[dev-noxfile]
 nox --install-only  # Set up virtual environments once
-nox -R  # Run linting and testing reusing the already existing virtual environments
+nox -R  # Run linting and testing reusing the existing virtual environments
 ```
 
-This will only install you package in *editable* mode and the minimum
-dependencies to be able to run `nox`, and then run all `nox` default sessions,
-which will run linters and tests.
+This will only install your package in *editable* mode and the minimum
+dependencies required to run `nox`. It will then run all `nox` default
+sessions, which include running linters and tests.
 
 !!! note
 
-    It's much faster to use `nox` with `--install-only` once (each time to
-    change or update dependencies you need to run it again) and then using `nox
-    -R` to run the sessions without re-creating the virtual environments.
+    It's much faster to use `nox` with `--install-only` once (each time you
+    change or update dependencies, you need to run it again) and then use `nox
+    -R` to run the sessions without recreating the virtual environments.
 
-    Otherwise `nox` will create many virtual environments each time you run it,
-    which is **very** slow.
+    Otherwise, `nox` will create many virtual environments each time you run
+    it, which is **very** slow.
 
 ### Verify the generated documentation works
 
-To generate the documentation you can use `mkdocs`:
+To generate the documentation, you can use `mkdocs`:
 
 ```sh
 pip install .[dev-mkdocs]  # Not necessary if you already installed .[dev]
 mkdocs serve
 ```
 
-If the command fails, look at the log warnings and errors and fix them.  If it
-worked, now there is a local web server serving the documentation, you can
-point your browser to Now you can point your browser to
-[http://127.0.0.1:8000](/http://127.0.0.1:8000/) to have a look.
+If the command fails, look at the log warnings and errors and fix them. If it
+worked, now there is a local web server serving the documentation. You can
+point your browser to [http://127.0.0.1:8000](http://127.0.0.1:8000) to have
+a look.
 
 !!! info
 
-    For API projects `docker` is needed to generate and serve documentation, as
-    the easiest way to use the [tool to generate the documentation from
-    `.proto`](https://github.com/pseudomuto/protoc-gen-doc) files is using
+    For API projects, `docker` is needed to generate and serve documentation,
+    as the easiest way to use the [tool to generate the documentation from
+    `.proto` files](https://github.com/pseudomuto/protoc-gen-doc) is using
     `docker`.
 
-### Initialize the GitHub pages website
+### Initialize the GitHub Pages website
 
-The generated documentation can be easily published via GitHub pages, and it
-will be automatically updated for new pushed and releases, but for that to work
-correctly, some initial setup is needed:
+The generated documentation can be easily published via GitHub Pages, and it
+will be automatically updated for new pushes and releases. However, some
+initial setup is needed for it to work correctly:
 
 ```sh
 pip install -e .[dev-mkdocs]  # Not necessary if you already installed .[dev]
 mike deploy --update-aliases next latest  # Creates the branch gh-pages locally
 mike set-default latest  # Makes the latest alias the default version
-git push upstream gh-pages  # Pushes the new branch upstream so the website is published
+git push upstream gh-pages  # Pushes the new branch upstream to publish the website
 ```
 
-Then make sure that GitHub pages is enabled in
+Then make sure that GitHub Pages is enabled in
 `https://github.com/<repo-owner>/<repo-name>/settings/pages`.
 
 If all went well, your website should be available soon via
-`https://<repo-owner>.github.io//<repo-name>/`.
+`https://<repo-owner>.github.io/<repo-name>/`.
 
 ## Migrate an existing project
 
-The easiest way to migrate an existing project is to just generate a new one
-basing all the inputs in the current project metadata and then overwritting the
-existing files.
+The easiest way to migrate an existing project is to generate a new one based
+on the current project metadata and then overwrite the existing files.
 
 It is recommended to commit all changes before doing this, so you can then use
 `git` to look at the changes.
@@ -146,7 +147,7 @@ cookiecutter gh:frequenz-floss/frequenz-repo-config-python --directory=cookiecut
 rsync -vr --exclude=.git/ new-project/ /path/to/existing/project
 cd /path/to/existing/project
 git diff
-# Fix all the `TODO`s and cleanup the generated files
+# Fix all the `TODO`s and clean up the generated files
 git commit -a
 ```
 
@@ -155,8 +156,8 @@ git commit -a
     The trailing slash in `new-project/` and the lack of it in
     `/path/to/existing/project` are meaningful to `rsync`.
 
-    Also make sure to **exclude** the `.git/` directory to avoid messing up
-    with your local git repository.
+    Also, make sure to **exclude** the `.git/` directory to avoid messing up
+    with your local Git repository.
 
 !!! tip
 
@@ -166,10 +167,10 @@ git commit -a
 
 ## Update an existing project
 
-To update an existing project you can use the [Cookiecutter *replay
+To update an existing project, you can use the [Cookiecutter *replay
 file*](https://cookiecutter.readthedocs.io/en/stable/advanced/replay.html) that
-was saved during the project generation.  The file is saved in
-`.cookiecutter-replay.json`.  Using this file you can re-run [Cookiecutter]
+was saved during the project generation. The file is saved as
+`.cookiecutter-replay.json`. Using this file, you can re-run [Cookiecutter]
 without having to enter all the inputs again.
 
 !!! warning
@@ -189,17 +190,17 @@ cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
 
 This will create a new commit with all the changes to the overwritten files.
 Bear in mind that all the `TODO`s will come back, so there will be quite a bit
-of cleanup to do.  You can easily check what was changed using `git show`, and
+of cleanup to do. You can easily check what was changed using `git show`, and
 you can use `git commit --amend` to amend the previous commit with the template
-updates, or create a new commit with the fixes.  You can also use `git citool`
-or `git gui` to easily add, remove or even discard (revert) changes in the
+updates, or create a new commit with the fixes. You can also use `git citool`
+or `git gui` to easily add, remove, or even discard (revert) changes in the
 templates update commit.
 
 !!! note
 
     The `project-directory` is the directory of your previously generated
     project. If you renamed it, then the files will be generated in a new
-    directory with the original name.  You can update the target directory in
+    directory with the original name. You can update the target directory in
     the replay file.
 
 !!! note
@@ -218,12 +219,12 @@ templates update commit.
 The [Cookiecutter] template uses some tools provided as a library by this
 project.
 
-Usually users don't need deal with it directly, but if you project needs some
-extra customization (like disabling `nox` sessions or adding new ones, or using
-different CLI options for some tools), then you'll need to.
+Usually, users don't need to deal with it directly, but if your project needs
+some extra customization (like disabling `nox` sessions or adding new ones, or
+using different CLI options for some tools), then you'll need to.
 
 You can find information about the extra features in the [API
-refence](reference/frequenz/repo/config/).
+reference](reference/frequenz/repo/config/).
 
 
 [Cookiecutter]: https://cookiecutter.readthedocs.io/en/stable

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Frequenz repository common configuration for Python
+# Frequenz repository configuration for Python
 
 ## Introduction
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,229 @@
---8<-- "README.md"
+# Frequenz repository common configuration for Python
+
+## Introduction
+
+This is very opinionated set of tools and configurations to setup a Python
+repository for [Frequenz](https://frequenz.com) projects.
+
+If offers:
+
+* [Cookiecutter] templates for scaffolding new projects
+* Trivial build of `noxfile.py` with some predefined sessions with all common
+  checks.
+* Tools to build protobuf/grpc files as Python, including type information.
+
+## Start a new project
+
+To start a new project you should first [install
+Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/installation.html).
+It is normally available in any Linux distribution, but some have a very old
+version (for example, Ubuntu/Debian).  You can [check which version your distro
+has in Repology](https://repology.org/project/cookiecutter/versions). You need
+**at least version 2.1.0**.  To make sure to get an up to date version you can
+always uses `pip` and install in a `venv`:
+
+```console
+$ python -m venv cookiecutter
+$ cd cookiecutter
+$ . bin/activate
+[cookiecutter] $ pip install cookiecutter
+Collecting cookiecutter
+...
+```
+
+Then just run cookiecutter where you want to create the new project. A new
+directory will be created with the generated project name. For example:
+
+```sh
+cd ~/devel
+cookiecutter gh:frequenz-floss/frequenz-repo-config-python --directory=cookiecutter
+```
+
+This will prompt for the project type, name and other configuration and
+generate the whole project for you.
+
+After completing it and fixing the `TODO`s you can amend the previous commit
+using `git commit --amend` or create a new commit for the changes using `git
+commit`.
+
+### Create the local development environment
+
+To start the development, you need to make sure your environment is correctly
+setup. One way to do this is by using a virtual environment and installing all
+the dependencies there:
+
+```sh
+# requires at least python version 3.11
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -e .[dev]
+```
+
+This will install you package in [*editable*
+mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html), so
+you can open a python interpreter and import your package modules and pick up
+any local changes without the need to reinstall.  You can now run tools
+directly, like `pytest`.
+
+### Verify the new repository is healthy using `nox`
+
+If you prefer to keep your virtual enviroment cleaner and avoid installing development dependencies, you can also use `nox` to create isolated environments for you:
+
+```sh
+pip install -e .[dev-noxfile]
+nox --install-only  # Set up virtual environments once
+nox -R  # Run linting and testing reusing the already existing virtual environments
+```
+
+This will only install you package in *editable* mode and the minimum
+dependencies to be able to run `nox`, and then run all `nox` default sessions,
+which will run linters and tests.
+
+!!! note
+
+    It's much faster to use `nox` with `--install-only` once (each time to
+    change or update dependencies you need to run it again) and then using `nox
+    -R` to run the sessions without re-creating the virtual environments.
+
+    Otherwise `nox` will create many virtual environments each time you run it,
+    which is **very** slow.
+
+### Verify the generated documentation works
+
+To generate the documentation you can use `mkdocs`:
+
+```sh
+pip install .[dev-mkdocs]  # Not necessary if you already installed .[dev]
+mkdocs serve
+```
+
+If the command fails, look at the log warnings and errors and fix them.  If it
+worked, now there is a local web server serving the documentation, you can
+point your browser to Now you can point your browser to
+[http://127.0.0.1:8000](/http://127.0.0.1:8000/) to have a look.
+
+!!! info
+
+    For API projects `docker` is needed to generate and serve documentation, as
+    the easiest way to use the [tool to generate the documentation from
+    `.proto`](https://github.com/pseudomuto/protoc-gen-doc) files is using
+    `docker`.
+
+### Initialize the GitHub pages website
+
+The generated documentation can be easily published via GitHub pages, and it
+will be automatically updated for new pushed and releases, but for that to work
+correctly, some initial setup is needed:
+
+```sh
+pip install -e .[dev-mkdocs]  # Not necessary if you already installed .[dev]
+mike deploy --update-aliases next latest  # Creates the branch gh-pages locally
+mike set-default latest  # Makes the latest alias the default version
+git push upstream gh-pages  # Pushes the new branch upstream so the website is published
+```
+
+Then make sure that GitHub pages is enabled in
+`https://github.com/<repo-owner>/<repo-name>/settings/pages`.
+
+If all went well, your website should be available soon via
+`https://<repo-owner>.github.io//<repo-name>/`.
+
+## Migrate an existing project
+
+The easiest way to migrate an existing project is to just generate a new one
+basing all the inputs in the current project metadata and then overwritting the
+existing files.
+
+It is recommended to commit all changes before doing this, so you can then use
+`git` to look at the changes.
+
+If you generate the new repo in a temporary directory, you can easily overwrite
+the files in your existing project by using `rsync` or similar tools:
+
+```sh
+cd /tmp
+cookiecutter gh:frequenz-floss/frequenz-repo-config-python --directory=cookiecutter
+rsync -vr --exclude=.git/ new-project/ /path/to/existing/project
+cd /path/to/existing/project
+git diff
+# Fix all the `TODO`s and cleanup the generated files
+git commit -a
+```
+
+!!! warning
+
+    The trailing slash in `new-project/` and the lack of it in
+    `/path/to/existing/project` are meaningful to `rsync`.
+
+    Also make sure to **exclude** the `.git/` directory to avoid messing up
+    with your local git repository.
+
+!!! tip
+
+    Please have a look at the follow-up steps listed in the [Start a new
+    project](#create-the-local-development-environment) section to finish the
+    setup.
+
+## Update an existing project
+
+To update an existing project you can use the [Cookiecutter *replay
+file*](https://cookiecutter.readthedocs.io/en/stable/advanced/replay.html) that
+was saved during the project generation.  The file is saved in
+`.cookiecutter-replay.json`.  Using this file you can re-run [Cookiecutter]
+without having to enter all the inputs again.
+
+!!! warning
+
+    Don't forget to commit all changes in your repository before doing this!
+    Files will be overwritten!
+
+```sh
+git commit -a  # commit all changes
+cd ..
+cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
+    --directory=cookiecutter \
+    --force \
+    --replay \
+    --replay-file project-directory/.cookiecutter-replay.json
+```
+
+This will create a new commit with all the changes to the overwritten files.
+Bear in mind that all the `TODO`s will come back, so there will be quite a bit
+of cleanup to do.  You can easily check what was changed using `git show`, and
+you can use `git commit --amend` to amend the previous commit with the template
+updates, or create a new commit with the fixes.  You can also use `git citool`
+or `git gui` to easily add, remove or even discard (revert) changes in the
+templates update commit.
+
+!!! note
+
+    The `project-directory` is the directory of your previously generated
+    project. If you renamed it, then the files will be generated in a new
+    directory with the original name.  You can update the target directory in
+    the replay file.
+
+!!! note
+
+    Please remember to keep your replay file up to date if you change any
+    metadata in the project.
+
+!!! tip
+
+    Please have a look at the follow-up steps listed in the [Start a new
+    project](#create-the-local-development-environment) section to finish the
+    setup.
+
+## Advanced usage
+
+The [Cookiecutter] template uses some tools provided as a library by this
+project.
+
+Usually users don't need deal with it directly, but if you project needs some
+extra customization (like disabling `nox` sessions or adding new ones, or using
+different CLI options for some tools), then you'll need to.
+
+You can find information about the extra features in the [API
+refence](reference/frequenz/repo/config/).
+
+
+[Cookiecutter]: https://cookiecutter.readthedocs.io/en/stable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ copyright: "Copyright © 2023 Frequenz Energy-as-a-Service GmbH"
 repo_name: "frequenz-repo-config-python"
 repo_url: "https://github.com/frequenz-floss/frequenz-repo-config-python"
 edit_uri: "edit/main/docs/"
+strict: true  # Treat warnings as errors
 
 # Build directories
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,20 +11,20 @@ description = "Frequenz repository setup tools and common configuration"
 readme = "README.md"
 license = { text = "MIT" }
 keywords = [
-  "frequenz",
-  "python",
-  "lib",
-  "repo-config",
-  "frequenz",
-  "package",
-  "project",
   "config",
-  "tool",
+  "frequenz",
+  "grpc",
+  "lib",
+  "library",
+  "mkdocs",
+  "nox",
+  "project",
+  "protobuf",
+  "python",
+  "repo-config",
   "repository",
   "setuptools",
-  "nox",
-  "grpc",
-  "protobuf",
+  "tool",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -166,7 +166,7 @@ dev = [
 ### API reference generation
 
 The API documnentation can be automatically generated from the source files using the
-[`freq.repo.config.mkdocs`][] package as when run as a
+[`frequenz.repo.config.mkdocs`][] package as when run as a
 [`mkdocs-gen-files`](https://oprypin.github.io/mkdocs-gen-files/) plugin script.
 
 To enable it you just need to make sure the `mkdocs-gen-files`, `mkdocs-literate-nav`

--- a/src/frequenz/repo/config/nox/__init__.py
+++ b/src/frequenz/repo/config/nox/__init__.py
@@ -3,7 +3,7 @@
 
 """Utilities to build noxfiles.
 
-The main entry point is the [`configure()`][configure] function, which will
+The main entry point is the [`configure()`][frequenz.repo.config.nox.configure] function, which will
 configure all nox sessions according to some configuration.
 
 To use the default options, you should call `configure()` using one of the [repository
@@ -35,15 +35,15 @@ nox.configure(config)
 If you need further customization or to define new sessions, you can use the
 following modules:
 
-- [`config`][]: Low-level utilities to configure nox sessions. It defines the
+- [`frequenz.repo.config.nox.config`][]: Low-level utilities to configure nox sessions. It defines the
   `Config` and CommandsOptions` classes and the actual implementation of the
   `configure()` function. It also defines the `get()` function, which can be
   used to get the currently used configuration object.
 
-- [`session`][]: Predefined nox sessions. These are the sessions that are used
+- [`frequenz.repo.config.nox.session`][]: Predefined nox sessions. These are the sessions that are used
   by default.
 
-- [`util`][]: General purpose utility functions.
+- [`frequenz.repo.config.nox.util`][]: General purpose utility functions.
 """
 
 from .config import configure

--- a/src/frequenz/repo/config/nox/__init__.py
+++ b/src/frequenz/repo/config/nox/__init__.py
@@ -3,8 +3,8 @@
 
 """Utilities to build noxfiles.
 
-The main entry point is the [`configure()`][frequenz.repo.config.nox.configure] function, which will
-configure all nox sessions according to some configuration.
+The main entry point is the [`configure()`][frequenz.repo.config.nox.configure]
+function, which will configure all nox sessions according to some configuration.
 
 To use the default options, you should call `configure()` using one of the [repository
 types][frequenz.repo.config.RepositoryType].  For example:
@@ -15,8 +15,9 @@ from frequenz.repo.config import RepositoryType, nox
 nox.configure(RepositoryType.LIB)
 ```
 
-Again, make sure to pick the correct project typedefault configuration based on the type of your
-project (`actor_config`, `api_config`, `app_config`, `lib_config`, `model_config`).
+Again, make sure to pick the correct project typedefault configuration based on the type
+of your project (`actor_config`, `api_config`, `app_config`, `lib_config`,
+`model_config`).
 
 If you need to use some custom configuration, you can start from the default settings in
 the [`frequenz.repo.config.nox.default`][] module,
@@ -32,16 +33,16 @@ config.opts.black.append("--diff")
 nox.configure(config)
 ```
 
-If you need further customization or to define new sessions, you can use the
-following modules:
+If you need further customization or to define new sessions, you can use the following
+modules:
 
-- [`frequenz.repo.config.nox.config`][]: Low-level utilities to configure nox sessions. It defines the
-  `Config` and CommandsOptions` classes and the actual implementation of the
-  `configure()` function. It also defines the `get()` function, which can be
-  used to get the currently used configuration object.
+- [`frequenz.repo.config.nox.config`][]: Low-level utilities to configure nox sessions.
+  It defines the `Config` and CommandsOptions` classes and the actual implementation of
+  the `configure()` function. It also defines the `get()` function, which can be used to
+  get the currently used configuration object.
 
-- [`frequenz.repo.config.nox.session`][]: Predefined nox sessions. These are the sessions that are used
-  by default.
+- [`frequenz.repo.config.nox.session`][]: Predefined nox sessions. These are the
+  sessions that are used by default.
 
 - [`frequenz.repo.config.nox.util`][]: General purpose utility functions.
 """

--- a/tests/integration/test_cookiecutter_generation.py
+++ b/tests/integration/test_cookiecutter_generation.py
@@ -36,7 +36,7 @@ def test_generation(tmp_path: pathlib.Path, repo_type: str) -> None:
         repo_config_path=cwd, repo_type=repo_type, repo_path=repo_path
     )
 
-    cmd = ". .venv/bin/activate; pip install .[dev-noxfile]; nox"
+    cmd = ". .venv/bin/activate; pip install .[dev-noxfile]; nox -e ci_checks_max pytest_min"
     print()
     print(f"Running in shell [{cwd}]: {cmd}")
     subprocess.run(cmd, shell=True, cwd=repo_path, check=True)


### PR DESCRIPTION
- Treat mkdocs warnings as errors
- Fix broken docs cross-references
- Adjust docs text to 88 columns
- Fix and sort project tags
- Add instructions to initialize the docs site
- Add advanced usage section pointing to the API
- Add link to Frequenz website
- Reestructure README headers
- Move most of the README to docs/index.md
- Add links to build status, PyPI package and docs website
- Shorten the README and home title
- Update RELEASE_NOTES
- Speed up integration tests
