### PR TITLE
Improve cookiecutter mkdocs configuration

### DIFF
--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -67,6 +67,10 @@ markdown_extensions:
   - admonition
   - attr_list
   - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
   - pymdownx.snippets:
       check_paths: true
   - pymdownx.superfences:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -102,6 +102,7 @@ plugins:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
+            - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
   - section-index
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -65,9 +65,6 @@ markdown_extensions:
   - admonition
   - attr_list
   - pymdownx.details
-  - pymdownx.superfences
-  - pymdownx.tasklist
-  - pymdownx.tabbed
   - pymdownx.snippets:
       check_paths: true
   - pymdownx.superfences:
@@ -75,6 +72,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: "!!python/name:pymdownx.superfences.fence_code_format"
+  - pymdownx.tabbed
+  - pymdownx.tasklist
   - toc:
       permalink: "¤"
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -71,6 +71,7 @@ markdown_extensions:
       anchor_linenums: true
       line_spans: __span
       pygments_lang_class: true
+  - pymdownx.keys
   - pymdownx.snippets:
       check_paths: true
   - pymdownx.superfences:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -25,6 +25,8 @@ theme:
     repo: fontawesome/brands/github
   custom_dir: docs/overrides
   features:
+    - content.code.annotate
+    - content.code.copy
     - navigation.instant
     - navigation.tabs
     - navigation.top


### PR DESCRIPTION
- Sort mkdocs `markdown_extensions`
- Add cross-reference for `typing-extensions`
- Add copy and annotation features to code
- Improve code blocks configuration
- Support rendering keys
