### PR TITLE
Allow specifying a src root path.

### DIFF
--- a/src/frequenz/repo/config/nox/config.py
+++ b/src/frequenz/repo/config/nox/config.py
@@ -14,6 +14,7 @@ The `configure()` function must be called before `get()` is used.
 
 import dataclasses as _dataclasses
 import itertools as _itertools
+from pathlib import Path
 from typing import Self, assert_never, overload
 
 import nox as _nox
@@ -86,6 +87,13 @@ class Config:
     tools invoked by the sessions.
     """
 
+    root_path: str | None = _dataclasses.field(default_factory=lambda: None)
+    """Path to the root of the repository source files.
+
+    Specifies the portion of the path to be removed from the source paths when
+    calculating the package name for the found packages.
+    """
+
     def __post_init__(self) -> None:
         """Initialize the configuration object.
 
@@ -138,12 +146,30 @@ class Config:
 
         Returns:
             The package names found in the `source_paths`.
+
+        Raises:
+            ValueError: If `root_path` is set but does not exist, or is not a directory.
         """
         if session.posargs:
             return session.posargs
 
+        root_path_list = (
+            list(_util.existing_paths([self.root_path])) if self.root_path else []
+        )
+        root_path: Path | None = None
+
+        if len(root_path_list) != 0:
+            root_path = root_path_list[0]
+        elif self.root_path:
+            raise ValueError(
+                f"Root path {self.root_path} does not exist, or is not a directory."
+            )
+
         sources_package_dirs_with_roots = (
-            (p, _util.find_toplevel_package_dirs(p))
+            (
+                p if root_path is None else root_path,
+                _util.find_toplevel_package_dirs(p, root=root_path),
+            )
             for p in _util.existing_paths(self.source_paths)
         )
 


### PR DESCRIPTION
Without this, the mypy function would generate `-p` statements for packages that
were not at the top level and thus were not found.

Due to this line:

```
pkg_args = _util.flatten(("-p", p) for p in conf.package_args(session))
```

The problem appeared when I was using `source_paths=["src/frequenz/app/fcr_balancing", "src/frequenz/actor"]` to avoid
getting a `-p` statement for `src/frequenz/app/simulate` (which we want to exclude).

```
nox > mypy --install-types --namespace-packages --non-interactive --explicit-package-bases --strict --exclude=src.frequenz.app.simulate -p fcr_balancing -p . -p docs -p noxfile -p tests
Can't find package 'fcr_balancing'
nox > Command mypy --install-types --namespace-packages --non-interactive --explicit-package-bases --strict --exclude=src.frequenz.app.simulate -p fcr_balancing -p . -p docs -p noxfile -p tests failed with exit code 2
```


Now the call looks like this:
```
nox > mypy --install-types --namespace-packages --non-interactive --explicit-package-bases --strict --exclude=src.frequenz.app.simulate -p frequenz.actor.fcr_balancing -p frequen
z.app.fcr_balancing -p docs -p noxfile -p tests
```

