### PR TITLE
Capitalize project name in title

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
 
 * Add linting to the CI with `protolint` for API projects.
 * Bump SDK version to v0.22.0.
+* Capitalize project name in title and expand shortened words.
 
 ## Bug Fixes
 

--- a/cookiecutter/local_extensions.py
+++ b/cookiecutter/local_extensions.py
@@ -92,17 +92,18 @@ def title(cookiecutter: dict[str, str]) -> str:
     Returns:
         The default site name.
     """
+    name = cookiecutter["name"].capitalize()
     match cookiecutter["type"]:
         case "actor":
-            return f"Frequenz {cookiecutter['name']} actor"
+            return f"Frequenz {name} Actor"
         case "api":
-            return f"Frequenz {cookiecutter['name']} API"
+            return f"Frequenz {name} API"
         case "lib":
-            return f"Freqenz {cookiecutter['name']} library"
+            return f"Freqenz {name} Library"
         case "app":
-            return f"Frequenz {cookiecutter['name']} app"
+            return f"Frequenz {name} Application"
         case "model":
-            return f"Frequenz {cookiecutter['name']} AI model"
+            return f"Frequenz {name} AI Model"
         case _ as repo_type:
             assert False, f"Unhandled repository type {repo_type!r}"
 


### PR DESCRIPTION
We also capitalize all words in the title to have a more titly feeling, and we expand shortened words, like app -> Application and lib -> Library.
