### PR TITLE
Fix protobuf config

### DIFF
--- a/src/frequenz/repo/config/protobuf.py
+++ b/src/frequenz/repo/config/protobuf.py
@@ -70,7 +70,8 @@ class ProtobufConfig:
         except KeyError:
             return cls(**defaults)
 
-        known_keys = frozenset(defaults.keys())
+        default = cls(**defaults)
+        known_keys = frozenset(dataclasses.asdict(default).keys())
         config_keys = frozenset(config.keys())
         if unknown_keys := config_keys - known_keys:
             _logger.warning(
@@ -80,4 +81,4 @@ class ProtobufConfig:
             )
 
         attrs = dict(defaults, **{k: config[k] for k in (known_keys & config_keys)})
-        return cls(**attrs)
+        return dataclasses.replace(default, **attrs)

--- a/src/frequenz/repo/config/protobuf.py
+++ b/src/frequenz/repo/config/protobuf.py
@@ -41,7 +41,7 @@ class ProtobufConfig:
 
     @classmethod
     def from_pyproject_toml(
-        cls, /, path: str = "pyproject.toml", **defaults: Any
+        cls, path: str = "pyproject.toml", /, **defaults: Any
     ) -> Self:
         """Create a new configuration by loading the options from a `pyproject.toml` file.
 


### PR DESCRIPTION
 Trying to override configuration for protobuf is not working properly as the defaults could be empty, making the `from_pyproject_toml()` think all are unknown keys, so not overriding anything.
