### PR TITLE
ci: Checkout submodules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -90,6 +94,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2
@@ -167,6 +173,8 @@ jobs:
       - name: Fetch sources
         if: steps.mike-metadata.outputs.version
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         if: steps.mike-metadata.outputs.version

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Cookiecutter: Now the CI workflow will checkout the submodules.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -62,6 +62,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -86,6 +88,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -115,6 +119,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2
@@ -192,6 +198,8 @@ jobs:
       - name: Fetch sources
         if: steps.mike-metadata.outputs.version
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -90,6 +94,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2
@@ -167,6 +173,8 @@ jobs:
       - name: Fetch sources
         if: steps.mike-metadata.outputs.version
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -60,6 +60,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -84,6 +86,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -113,6 +117,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2
@@ -190,6 +196,8 @@ jobs:
       - name: Fetch sources
         if: steps.mike-metadata.outputs.version
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -90,6 +94,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2
@@ -167,6 +173,8 @@ jobs:
       - name: Fetch sources
         if: steps.mike-metadata.outputs.version
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -90,6 +94,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2
@@ -167,6 +173,8 @@ jobs:
       - name: Fetch sources
         if: steps.mike-metadata.outputs.version
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -90,6 +94,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2
@@ -167,6 +173,8 @@ jobs:
       - name: Fetch sources
         if: steps.mike-metadata.outputs.version
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         if: steps.mike-metadata.outputs.version


### PR DESCRIPTION
This is necessary for API repositories and it is harmless for the rest (and usually if any other repository have submodules, we'll want to pull them), so we include it for all.
