### PR TITLE
Add workflow to check for release notes update

### DIFF
--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -1,0 +1,28 @@
+name: Release Notes Check
+
+on:
+  merge_group:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # For `skip-label` only.
+      - "labeled"
+      - "unlabeled"
+
+
+jobs:
+  check-release-notes:
+    name: Check release notes are updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a release notes update
+        if: github.event_name == 'pull_request'
+        uses: brettcannon/check-for-changed-files@4170644959a21843b31f1181f2a1761d65ef4791 # v1.2.0
+        with:
+          file-pattern: "RELEASE_NOTES.md"
+          prereq-pattern: "src/**"
+          skip-label: "cmd:skip-release-notes"
+          failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,11 +6,37 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- To make the new workflow to check if release notes were updated you should add the check to the branch protection rules of your repository to require this check to pass. You should also add a new label *"cmd:skip-release-notes"* to be able to override the check. You can use the following script to do it:
+
+  ```sh
+  repo=...  # org/repo
+  token=... # GitHub token with the correct permissions
+  name="cmd:skip-release-notes"
+  desc="It is not necessary to update release notes for this PR"
+  color="930F79"
+
+  # Using cURL
+  curl -L \
+      -X POST \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $token" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      -d '{"name":"'"$name"'","description":"'"$desc"'","color":"'"$color"'"}' \
+      "https://api.github.com/repos/$repo/labels"
+
+  # Using the gh tool (no need for a token if you already have it configured)
+  gh api -X POST \
+      -f name="$name" -f description="$desc" -f color="$color" \
+      "repos/$repo/labels"
+  ```
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Cookiecutter: Add a new GitHub workflow to check that release notes were updated.
+
+  This workflow will check PRs to see if a change was done in the `src/` directory, and if so, it will fail if the `RELEASE_NOTES.md` wasn't also updated.
+
+  Users can override this by assigning the label `cmd:skip-release-notes` to the PR for changes that don't really need a release notes update.
 
 ## Bug Fixes
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/release-notes-check.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/release-notes-check.yml
@@ -1,0 +1,30 @@
+name: Release Notes Check
+
+on:
+  merge_group:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # For `skip-label` only.
+      - "labeled"
+      - "unlabeled"
+
+
+jobs:
+  check-release-notes:
+    name: Check release notes are updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a release notes update
+        if: github.event_name == 'pull_request'
+        uses: brettcannon/check-for-changed-files@4170644959a21843b31f1181f2a1761d65ef4791 # v1.2.0
+        with:
+          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
+          # token: {{'${{ secrets.github_token }}'}}
+          file-pattern: "RELEASE_NOTES.md"
+          prereq-pattern: "src/**"
+          skip-label: "cmd:skip-release-notes"
+          failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,6 +109,50 @@ sessions, which include running linters and tests.
     Otherwise, `nox` will create many virtual environments each time you run
     it, which is **very** slow.
 
+### Configure the release notes check GitHub workflow
+
+By default a workflow to check if the release notes were updated is
+included. This workflow will check PRs to see if a change was done in the
+`src/` directory, and if so, it will fail if the `RELEASE_NOTES.md` wasn't also
+updated.
+
+But this check will not be enforced unless some extra configuration is done. To
+enforce the check for PRs to be merged you need to go to the *GitHub repository
+-> Settings -> Branches* and select the rule for the branch you want to protect.
+
+Then in the rules search for the *Require status checks to pass before merging*
+checkbox and search for *"Check release notes are updated"* in the search box.
+
+As sometimes it is OK for PRs not to have release notes, as maybe some changes
+don't impact the end user, this workflow can be overridden by assigning the
+label `cmd:skip-release-notes` to the PR. To be able to do this, you also need
+to add that label to the repository.
+
+You can do this from the GitHub web interface, or using one of the following
+commands:
+
+```sh
+repo=...  # org/repo
+token=... # GitHub token with the correct permissions
+name="cmd:skip-release-notes"
+desc="It is not necessary to update release notes for this PR"
+color="930F79"
+
+# Using cURL
+curl -L \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $token" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    -d '{"name":"'"$name"'","description":"'"$desc"'","color":"'"$color"'"}' \
+    "https://api.github.com/repos/$repo/labels"
+
+# Using the gh tool (no need for a token if you already have it configured)
+gh api -X POST \
+    -f name="$name" -f description="$desc" -f color="$color" \
+    "repos/$repo/labels"
+```
+
 ### Verify the generated documentation works
 
 To generate the documentation, you can use `mkdocs`:

--- a/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
@@ -2,6 +2,7 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./CODEOWNERS:* TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)# Temporary, should probably change
 ./README.md:TODO(cookiecutter): Improve the README file

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/release-notes-check.yml
@@ -1,0 +1,30 @@
+name: Release Notes Check
+
+on:
+  merge_group:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # For `skip-label` only.
+      - "labeled"
+      - "unlabeled"
+
+
+jobs:
+  check-release-notes:
+    name: Check release notes are updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a release notes update
+        if: github.event_name == 'pull_request'
+        uses: brettcannon/check-for-changed-files@4170644959a21843b31f1181f2a1761d65ef4791 # v1.2.0
+        with:
+          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
+          # token: ${{ secrets.github_token }}
+          file-pattern: "RELEASE_NOTES.md"
+          prereq-pattern: "src/**"
+          skip-label: "cmd:skip-release-notes"
+          failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"

--- a/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
@@ -2,6 +2,7 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file
 ./mkdocs.yml:            # TODO(cookiecutter): You might want to add other external references here

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/release-notes-check.yml
@@ -1,0 +1,30 @@
+name: Release Notes Check
+
+on:
+  merge_group:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # For `skip-label` only.
+      - "labeled"
+      - "unlabeled"
+
+
+jobs:
+  check-release-notes:
+    name: Check release notes are updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a release notes update
+        if: github.event_name == 'pull_request'
+        uses: brettcannon/check-for-changed-files@4170644959a21843b31f1181f2a1761d65ef4791 # v1.2.0
+        with:
+          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
+          # token: ${{ secrets.github_token }}
+          file-pattern: "RELEASE_NOTES.md"
+          prereq-pattern: "src/**"
+          skip-label: "cmd:skip-release-notes"
+          failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"

--- a/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
@@ -2,6 +2,7 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file
 ./mkdocs.yml:            # TODO(cookiecutter): You might want to add other external references here

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/release-notes-check.yml
@@ -1,0 +1,30 @@
+name: Release Notes Check
+
+on:
+  merge_group:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # For `skip-label` only.
+      - "labeled"
+      - "unlabeled"
+
+
+jobs:
+  check-release-notes:
+    name: Check release notes are updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a release notes update
+        if: github.event_name == 'pull_request'
+        uses: brettcannon/check-for-changed-files@4170644959a21843b31f1181f2a1761d65ef4791 # v1.2.0
+        with:
+          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
+          # token: ${{ secrets.github_token }}
+          file-pattern: "RELEASE_NOTES.md"
+          prereq-pattern: "src/**"
+          skip-label: "cmd:skip-release-notes"
+          failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
@@ -2,6 +2,7 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file
 ./mkdocs.yml:            # TODO(cookiecutter): You might want to add other external references here

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/release-notes-check.yml
@@ -1,0 +1,30 @@
+name: Release Notes Check
+
+on:
+  merge_group:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # For `skip-label` only.
+      - "labeled"
+      - "unlabeled"
+
+
+jobs:
+  check-release-notes:
+    name: Check release notes are updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a release notes update
+        if: github.event_name == 'pull_request'
+        uses: brettcannon/check-for-changed-files@4170644959a21843b31f1181f2a1761d65ef4791 # v1.2.0
+        with:
+          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
+          # token: ${{ secrets.github_token }}
+          file-pattern: "RELEASE_NOTES.md"
+          prereq-pattern: "src/**"
+          skip-label: "cmd:skip-release-notes"
+          failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"

--- a/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
@@ -2,6 +2,7 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file
 ./mkdocs.yml:            # TODO(cookiecutter): You might want to add other external references here

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/release-notes-check.yml
@@ -1,0 +1,30 @@
+name: Release Notes Check
+
+on:
+  merge_group:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # For `skip-label` only.
+      - "labeled"
+      - "unlabeled"
+
+
+jobs:
+  check-release-notes:
+    name: Check release notes are updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a release notes update
+        if: github.event_name == 'pull_request'
+        uses: brettcannon/check-for-changed-files@4170644959a21843b31f1181f2a1761d65ef4791 # v1.2.0
+        with:
+          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
+          # token: ${{ secrets.github_token }}
+          file-pattern: "RELEASE_NOTES.md"
+          prereq-pattern: "src/**"
+          skip-label: "cmd:skip-release-notes"
+          failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"


### PR DESCRIPTION
This workflow will check PRs to see if a change was done in the `src/` directory, and if so, it will fail if the `RELEASE_NOTES.md` wasn't also updated.

Users can override this by assigning the label `cmd:skip-release-notes` to the PR for changes that don't really need a release notes update.

- cookiecutter: Add workflow to check for release notes update
- Add the release notes check workflow
