### PR TITLE
Add editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset, indent style and trimming of whitespace
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,md,proto,py,pyi,toml,yaml,yml}}]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.{py,pyi}]
+indent_size = 4
+
+# 2 space indentation
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,proto,toml,yaml,yml}}]
+indent_size = 2
+
+# No indentation size specified for *.md because different blocks have
+# different indentation rules

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,6 +24,7 @@
       - "**/*.toml"
       - "**/*.yaml"
       - "**/*.yml"
+      - ".editorconfig"
       - ".git*"
       - ".git*/**"
       - CODEOWNERS

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,8 @@
 
   This makes sure that we don't ship useless files when building the distribution package and that we include all the relevant files too, like generated *.pyi files for API repositories.
 
+- Add an `.editorconfig` file to ensure a common basic editor configuration for different file types.
+
 ## Bug Fixes
 
 - The distribution package doesn't include tests and other useless files anymore.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.editorconfig
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset, indent style and trimming of whitespace
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,md,proto,py,pyi,toml,yaml,yml}}]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.{py,pyi}]
+indent_size = 4
+
+# 2 space indentation
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,proto,toml,yaml,yml}}]
+indent_size = 2
+
+# No indentation size specified for *.md because different blocks have
+# different indentation rules

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/labeler.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/labeler.yml
@@ -44,6 +44,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - ".editorconfig"
   - ".git*"
   - ".git*/**"
   - "docs/*.py"

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.editorconfig
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset, indent style and trimming of whitespace
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,md,proto,py,pyi,toml,yaml,yml}}]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.{py,pyi}]
+indent_size = 4
+
+# 2 space indentation
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,proto,toml,yaml,yml}}]
+indent_size = 2
+
+# No indentation size specified for *.md because different blocks have
+# different indentation rules

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/labeler.yml
@@ -40,6 +40,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - ".editorconfig"
   - ".git*"
   - ".git*/**"
   - "docs/*.py"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.editorconfig
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset, indent style and trimming of whitespace
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,md,proto,py,pyi,toml,yaml,yml}}]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.{py,pyi}]
+indent_size = 4
+
+# 2 space indentation
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,proto,toml,yaml,yml}}]
+indent_size = 2
+
+# No indentation size specified for *.md because different blocks have
+# different indentation rules

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/labeler.yml
@@ -40,6 +40,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - ".editorconfig"
   - ".git*"
   - ".git*/**"
   - "docs/*.py"

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.editorconfig
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset, indent style and trimming of whitespace
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,md,proto,py,pyi,toml,yaml,yml}}]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.{py,pyi}]
+indent_size = 4
+
+# 2 space indentation
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,proto,toml,yaml,yml}}]
+indent_size = 2
+
+# No indentation size specified for *.md because different blocks have
+# different indentation rules

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/labeler.yml
@@ -40,6 +40,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - ".editorconfig"
   - ".git*"
   - ".git*/**"
   - "docs/*.py"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.editorconfig
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset, indent style and trimming of whitespace
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,md,proto,py,pyi,toml,yaml,yml}}]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.{py,pyi}]
+indent_size = 4
+
+# 2 space indentation
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,proto,toml,yaml,yml}}]
+indent_size = 2
+
+# No indentation size specified for *.md because different blocks have
+# different indentation rules

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/labeler.yml
@@ -40,6 +40,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - ".editorconfig"
   - ".git*"
   - ".git*/**"
   - "docs/*.py"

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.editorconfig
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset, indent style and trimming of whitespace
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,md,proto,py,pyi,toml,yaml,yml}}]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.{py,pyi}]
+indent_size = 4
+
+# 2 space indentation
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,proto,toml,yaml,yml}}]
+indent_size = 2
+
+# No indentation size specified for *.md because different blocks have
+# different indentation rules

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/labeler.yml
@@ -40,6 +40,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - ".editorconfig"
   - ".git*"
   - ".git*/**"
   - "docs/*.py"


### PR DESCRIPTION
Editorconfig is a standard way to specific basic editor configuration accross different editors.

For more information see https://editorconfig.org/.

- cookiecutter: Add .editorconfig
- Add .editorconfig

Fixes #24.
