### PR TITLE
Add MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+exclude CODEOWNERS
+exclude noxfile.py
+recursive-exclude .github *
+recursive-exclude tests *
+recursive-exclude tests_golden *
+recursive-include py *.pyi

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,4 +40,6 @@
 
 ## Bug Fixes
 
+- The distribution package doesn't include tests and other useless files anymore.
+
 - Cookiecutter: Now the CI workflow will checkout the submodules.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,11 +32,17 @@
 
 ## New Features
 
-- Cookiecutter: Add a new GitHub workflow to check that release notes were updated.
+### Cookietutter template
+
+- Add a new GitHub workflow to check that release notes were updated.
 
   This workflow will check PRs to see if a change was done in the `src/` directory, and if so, it will fail if the `RELEASE_NOTES.md` wasn't also updated.
 
   Users can override this by assigning the label `cmd:skip-release-notes` to the PR for changes that don't really need a release notes update.
+
+- Add `MANIFEST.in` file.
+
+  This makes sure that we don't ship useless files when building the distribution package and that we include all the relevant files too, like generated *.pyi files for API repositories.
 
 ## Bug Fixes
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/MANIFEST.in
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/MANIFEST.in
@@ -1,0 +1,16 @@
+exclude .gitignore
+{%- if cookiecutter.type == "api" %}
+exclude .gitmodules
+{%- endif %}
+exclude CODEOWNERS
+exclude noxfile.py
+recursive-exclude .github *
+{%- if cookiecutter.type == "api" %}
+recursive-exclude pytests *
+{%- else %}
+recursive-exclude tests *
+{%- endif %}
+recursive-include py *.pyi
+{%- if cookiecutter.type == "api" %}
+recursive-include submodules *.proto
+{%- endif %}

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/MANIFEST.in
@@ -1,0 +1,6 @@
+exclude .gitignore
+exclude CODEOWNERS
+exclude noxfile.py
+recursive-exclude .github *
+recursive-exclude tests *
+recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/MANIFEST.in
@@ -1,0 +1,8 @@
+exclude .gitignore
+exclude .gitmodules
+exclude CODEOWNERS
+exclude noxfile.py
+recursive-exclude .github *
+recursive-exclude pytests *
+recursive-include py *.pyi
+recursive-include submodules *.proto

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/MANIFEST.in
@@ -1,0 +1,6 @@
+exclude .gitignore
+exclude CODEOWNERS
+exclude noxfile.py
+recursive-exclude .github *
+recursive-exclude tests *
+recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/MANIFEST.in
@@ -1,0 +1,6 @@
+exclude .gitignore
+exclude CODEOWNERS
+exclude noxfile.py
+recursive-exclude .github *
+recursive-exclude tests *
+recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/MANIFEST.in
@@ -1,0 +1,6 @@
+exclude .gitignore
+exclude CODEOWNERS
+exclude noxfile.py
+recursive-exclude .github *
+recursive-exclude tests *
+recursive-include py *.pyi


### PR DESCRIPTION
This makes sure that we don't ship useless files when building the distribution package and that we include all the relevant files too, like generated *.pyi files for API repositories.

- Add manifest file
- cookiecutter: Add MANIFEST.in file

This is a great leap forward for #13.
