### PR TITLE
Add cookiecutter sections to `RELEASE_NOTES.md`

### DIFF
--- a/.github/RELEASE_NOTES.template.md
+++ b/.github/RELEASE_NOTES.template.md
@@ -8,10 +8,22 @@
 
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
+### Cookiecutter template
+
+<!-- Here upgrade steps for cookiecutter specifically -->
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->
 
+### Cookiecutter template
+
+<!-- Here new features for cookiecutter specifically -->
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+
+### Cookiecutter template
+
+<!-- Here bug fixes for cookiecutter specifically -->

--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -23,6 +23,6 @@ jobs:
         uses: brettcannon/check-for-changed-files@4170644959a21843b31f1181f2a1761d65ef4791 # v1.2.0
         with:
           file-pattern: "RELEASE_NOTES.md"
-          prereq-pattern: "src/**"
+          prereq-pattern: "{src,cookiecutter}/**"
           skip-label: "cmd:skip-release-notes"
           failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
 
 ## Upgrading
 
+### Cookiecutter template
+
 - To make the new workflow to check if release notes were updated you should add the check to the branch protection rules of your repository to require this check to pass. You should also add a new label *"cmd:skip-release-notes"* to be able to override the check. You can use the following script to do it:
 
   ```sh
@@ -32,7 +34,7 @@
 
 ## New Features
 
-### Cookietutter template
+### Cookiecutter template
 
 - Add a new GitHub workflow to check that release notes were updated.
 
@@ -48,4 +50,6 @@
 
 - The distribution package doesn't include tests and other useless files anymore.
 
-- Cookiecutter: Now the CI workflow will checkout the submodules.
+### Cookiecutter template
+
+- Now the CI workflow will checkout the submodules.


### PR DESCRIPTION
This makes it easier for users to know which changes are code changes and which are cookiecutter template changes.

Also require release notes for changes in cookiecutter templates. The workflow to check for updates to release notes wasn't taking into account changes to cookiecutter templates, which are very important to notify to users.
