### PR TITLE
Fix release notes check for API repos

### DIFF
--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/release-notes-check.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/release-notes-check.yml
@@ -25,6 +25,10 @@ jobs:
           # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
           # token: {{'${{ secrets.github_token }}'}}
           file-pattern: "RELEASE_NOTES.md"
+          {%- if cookiecutter.type == "api" %}
+          prereq-pattern: "{proto,py}/**"
+          {%- else %}
           prereq-pattern: "src/**"
+          {%- endif %}
           skip-label: "cmd:skip-release-notes"
           failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/release-notes-check.yml
@@ -25,6 +25,6 @@ jobs:
           # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
           # token: ${{ secrets.github_token }}
           file-pattern: "RELEASE_NOTES.md"
-          prereq-pattern: "src/**"
+          prereq-pattern: "{proto,py}/**"
           skip-label: "cmd:skip-release-notes"
           failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"


### PR DESCRIPTION
For API repos we need to check if files in the `proto/` or `py/` directories were updated, not `src/`.
