### PR TITLE
Fix several bugs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,12 +15,9 @@ indent_style = space
 trim_trailing_whitespace = true
 
 # 4 space indentation
-[*.{py,pyi}]
+[*.{md,py,pyi}]
 indent_size = 4
 
 # 2 space indentation
 [{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,proto,toml,yaml,yml}}]
 indent_size = 2
-
-# No indentation size specified for *.md because different blocks have
-# different indentation rules

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,14 @@
+exclude .cookiecutter-replay.json
+exclude .darglint
+exclude .editorconfig
+exclude .gitignore
 exclude CODEOWNERS
+exclude CONTRIBUTING.md
+exclude mkdocs.yml
 exclude noxfile.py
 recursive-exclude .github *
+recursive-exclude cookiecutter *
+recursive-exclude docs *
 recursive-exclude tests *
 recursive-exclude tests_golden *
 recursive-include py *.pyi

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,7 +52,11 @@
 
 - The distribution package doesn't include tests and other useless files anymore.
 
-- nox: When discovering path *extra paths*, now paths will not be added if they are also *source paths*, as we don't want any duplicates.
+- nox
+
+  * When discovering path *extra paths*, now paths will not be added if they are also *source paths*, as we don't want any duplicates.
+
+  * Fix copying of `Config` and `CommandOptions` objects.
 
 ### Cookiecutter template
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,10 @@
 
 ## Upgrading
 
+- nox: Now the default configuration for API repositories will not automatically add `pytests` as an `extra_path`
+
+  The `pytests` directory is not a standard directory that will be auto-discovered by `pytest`, so it should always be included in the `pyproject.toml` file, in the `tool.pytest.ini_options.testpaths` array. Please check your API project is properly configured.
+
 ### Cookiecutter template
 
 - To make the new workflow to check if release notes were updated you should add the check to the branch protection rules of your repository to require this check to pass. You should also add a new label *"cmd:skip-release-notes"* to be able to override the check. You can use the following script to do it:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -67,3 +67,5 @@
 - Now the CI workflow will checkout the submodules.
 
 - Fix adding of an empty keyword.
+
+- Don't distribute development files in the source distribution.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,3 +65,5 @@
 ### Cookiecutter template
 
 - Now the CI workflow will checkout the submodules.
+
+- Fix adding of an empty keyword.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,6 +52,8 @@
 
 - The distribution package doesn't include tests and other useless files anymore.
 
+- nox: When discovering path *extra paths*, now paths will not be added if they are also *source paths*, as we don't want any duplicates.
+
 ### Cookiecutter template
 
 - Now the CI workflow will checkout the submodules.

--- a/cookiecutter/local_extensions.py
+++ b/cookiecutter/local_extensions.py
@@ -172,7 +172,7 @@ def keywords(cookiecutter: dict[str, str]) -> str:
     cookiecutter_keywords = cookiecutter["keywords"]
     if cookiecutter_keywords == default:
         cookiecutter_keywords = ""
-    extended_keywords.extend(k.strip() for k in cookiecutter_keywords.split(","))
+    extended_keywords.extend(k.strip() for k in cookiecutter_keywords.split(",") if k)
     return _json.dumps(extended_keywords)
 
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/MANIFEST.in
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/MANIFEST.in
@@ -1,10 +1,16 @@
+exclude .cookiecutter-replay.json
+exclude .darglint
+exclude .editorconfig
 exclude .gitignore
 {%- if cookiecutter.type == "api" %}
 exclude .gitmodules
 {%- endif %}
 exclude CODEOWNERS
+exclude CONTRIBUTING.md
+exclude mkdocs.yml
 exclude noxfile.py
 recursive-exclude .github *
+recursive-exclude docs *
 {%- if cookiecutter.type == "api" %}
 recursive-exclude pytests *
 {%- else %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,8 +107,8 @@ plugins:
             - https://docs.python.org/3/objects.inv
             - https://mkdocstrings.github.io/objects.inv
             - https://nox.thea.codes/en/stable/objects.inv
-            - https://setuptools.pypa.io/en/latest/objects.inv
             - https://oprypin.github.io/mkdocs-gen-files/objects.inv
+            - https://setuptools.pypa.io/en/latest/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
   - section-index

--- a/src/frequenz/repo/config/nox/config.py
+++ b/src/frequenz/repo/config/nox/config.py
@@ -92,7 +92,7 @@ class Config:
         This will add extra paths discovered in config files and other sources.
         """
         for path in _util.discover_paths():
-            if path not in self.extra_paths:
+            if path not in self.extra_paths and path not in self.source_paths:
                 self.extra_paths.append(path)
 
     def copy(self, /) -> Self:

--- a/src/frequenz/repo/config/nox/config.py
+++ b/src/frequenz/repo/config/nox/config.py
@@ -53,7 +53,16 @@ class CommandsOptions:
         Returns:
             The copy of self.
         """
-        return _dataclasses.replace(self)
+        return _dataclasses.replace(
+            self,
+            black=self.black.copy(),
+            darglint=self.darglint.copy(),
+            isort=self.isort.copy(),
+            mypy=self.mypy.copy(),
+            pydocstyle=self.pydocstyle.copy(),
+            pylint=self.pylint.copy(),
+            pytest=self.pytest.copy(),
+        )
 
 
 @_dataclasses.dataclass(kw_only=True, slots=True)
@@ -101,7 +110,13 @@ class Config:
         Returns:
             The copy of self.
         """
-        return _dataclasses.replace(self)
+        return _dataclasses.replace(
+            self,
+            opts=self.opts.copy(),
+            sessions=self.sessions.copy(),
+            source_paths=self.source_paths.copy(),
+            extra_paths=self.extra_paths.copy(),
+        )
 
     def path_args(self, session: _nox.Session, /) -> list[str]:
         """Return the file paths to run the checks on.

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -88,8 +88,9 @@ api_command_options: _config.CommandsOptions = common_command_options.copy()
 api_config: _config.Config = common_config.copy()
 """Default configuration for APIs.
 
-Same as `common_config`, but with `source_paths` replacing `"src"` with `"py"`
-and `extra_paths` replacing `"tests"` with `"pytests"`.
+Same as `common_config`, but with an empty `source_paths` (as the sources are
+automatically generated, we don't want to test anything in there) and replacing `"src"`
+with `"py"` and `extra_paths` replacing `"tests"` with `"pytests"`.
 """
 
 # We don't check the sources at all because they are automatically generated.

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -24,8 +24,6 @@ They can be modified before being passed to
 method.
 """
 
-import dataclasses
-
 from . import config as _config
 from . import util as _util
 
@@ -87,19 +85,19 @@ actor_config: _config.Config = common_config.copy()
 api_command_options: _config.CommandsOptions = common_command_options.copy()
 """Default command-line options for APIs."""
 
-api_config: _config.Config = dataclasses.replace(
-    common_config,
-    opts=api_command_options,
-    # We don't check the sources at all because they are automatically generated.
-    source_paths=[],
-    # We adapt the path to the tests.
-    extra_paths=list(_util.replace(common_config.extra_paths, {"tests": "pytests"})),
-)
+api_config: _config.Config = common_config.copy()
 """Default configuration for APIs.
 
 Same as `common_config`, but with `source_paths` replacing `"src"` with `"py"`
 and `extra_paths` replacing `"tests"` with `"pytests"`.
 """
+
+# We don't check the sources at all because they are automatically generated.
+api_config.source_paths = []
+# We adapt the path to the tests.
+api_config.extra_paths = list(
+    _util.replace(common_config.extra_paths, {"tests": "pytests"})
+)
 
 app_command_options: _config.CommandsOptions = common_command_options.copy()
 """Default command-line options for applications."""

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -25,7 +25,6 @@ method.
 """
 
 from . import config as _config
-from . import util as _util
 
 common_command_options: _config.CommandsOptions = _config.CommandsOptions(
     black=[
@@ -89,16 +88,11 @@ api_config: _config.Config = common_config.copy()
 """Default configuration for APIs.
 
 Same as `common_config`, but with an empty `source_paths` (as the sources are
-automatically generated, we don't want to test anything in there) and replacing `"src"`
-with `"py"` and `extra_paths` replacing `"tests"` with `"pytests"`.
+automatically generated, we don't want to test anything in there).
 """
 
 # We don't check the sources at all because they are automatically generated.
 api_config.source_paths = []
-# We adapt the path to the tests.
-api_config.extra_paths = list(
-    _util.replace(common_config.extra_paths, {"tests": "pytests"})
-)
 
 app_command_options: _config.CommandsOptions = common_command_options.copy()
 """Default command-line options for applications."""

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/MANIFEST.in
@@ -1,6 +1,12 @@
+exclude .cookiecutter-replay.json
+exclude .darglint
+exclude .editorconfig
 exclude .gitignore
 exclude CODEOWNERS
+exclude CONTRIBUTING.md
+exclude mkdocs.yml
 exclude noxfile.py
 recursive-exclude .github *
+recursive-exclude docs *
 recursive-exclude tests *
 recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -14,7 +14,7 @@ name = "frequenz-actor-test"
 description = "Test description"
 readme = "README.md"
 license = { text = "MIT" }
-keywords = ["frequenz", "python", "actor", "test", ""]
+keywords = ["frequenz", "python", "actor", "test"]
 classifiers = [ # TODO(cookiecutter): Remove and add more if appropriate
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/MANIFEST.in
@@ -1,8 +1,14 @@
+exclude .cookiecutter-replay.json
+exclude .darglint
+exclude .editorconfig
 exclude .gitignore
 exclude .gitmodules
 exclude CODEOWNERS
+exclude CONTRIBUTING.md
+exclude mkdocs.yml
 exclude noxfile.py
 recursive-exclude .github *
+recursive-exclude docs *
 recursive-exclude pytests *
 recursive-include py *.pyi
 recursive-include submodules *.proto

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -14,7 +14,7 @@ name = "frequenz-api-test"
 description = "Test description"
 readme = "README.md"
 license = { text = "MIT" }
-keywords = ["frequenz", "python", "api", "grpc", "protobuf", "rpc", "test", ""]
+keywords = ["frequenz", "python", "api", "grpc", "protobuf", "rpc", "test"]
 classifiers = [ # TODO(cookiecutter): Remove and add more if appropriate
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/MANIFEST.in
@@ -1,6 +1,12 @@
+exclude .cookiecutter-replay.json
+exclude .darglint
+exclude .editorconfig
 exclude .gitignore
 exclude CODEOWNERS
+exclude CONTRIBUTING.md
+exclude mkdocs.yml
 exclude noxfile.py
 recursive-exclude .github *
+recursive-exclude docs *
 recursive-exclude tests *
 recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -14,7 +14,7 @@ name = "frequenz-app-test"
 description = "Test description"
 readme = "README.md"
 license = { text = "MIT" }
-keywords = ["frequenz", "python", "app", "application", "test", ""]
+keywords = ["frequenz", "python", "app", "application", "test"]
 classifiers = [ # TODO(cookiecutter): Remove and add more if appropriate
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/MANIFEST.in
@@ -1,6 +1,12 @@
+exclude .cookiecutter-replay.json
+exclude .darglint
+exclude .editorconfig
 exclude .gitignore
 exclude CODEOWNERS
+exclude CONTRIBUTING.md
+exclude mkdocs.yml
 exclude noxfile.py
 recursive-exclude .github *
+recursive-exclude docs *
 recursive-exclude tests *
 recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -14,7 +14,7 @@ name = "frequenz-test"
 description = "Test description"
 readme = "README.md"
 license = { text = "MIT" }
-keywords = ["frequenz", "python", "lib", "library", "test", ""]
+keywords = ["frequenz", "python", "lib", "library", "test"]
 classifiers = [ # TODO(cookiecutter): Remove and add more if appropriate
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/MANIFEST.in
@@ -1,6 +1,12 @@
+exclude .cookiecutter-replay.json
+exclude .darglint
+exclude .editorconfig
 exclude .gitignore
 exclude CODEOWNERS
+exclude CONTRIBUTING.md
+exclude mkdocs.yml
 exclude noxfile.py
 recursive-exclude .github *
+recursive-exclude docs *
 recursive-exclude tests *
 recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -14,7 +14,7 @@ name = "frequenz-model-test"
 description = "Test description"
 readme = "README.md"
 license = { text = "MIT" }
-keywords = ["frequenz", "python", "model", "ai", "ml", "machine-learning", "test", ""]
+keywords = ["frequenz", "python", "model", "ai", "ml", "machine-learning", "test"]
 classifiers = [ # TODO(cookiecutter): Remove and add more if appropriate
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",


### PR DESCRIPTION
- Don't add discovered extra path if it's a source path
- Fix copying of `Config` and `CommandOptions`
- Fix `defaults.api_config` documentation
- Remove hack to account for the `pytests` directory
- Sort `mkdocs.yml` import inventories
- cookiecutter: Fix adding of an empty keyword
- editorconfig: Use 4 spaces identation for Markdown files
- Remove unnecessary py.typed file
- Don't ship development files in source distribution
- cookiecutter: Don't ship devel files in source distribution
