### PR TITLE
Add linting of code examples in docstrings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -61,6 +61,7 @@ body:
         - Tools to configure nox (part:nox)
         - Tools to configure protobufs (part:protobuf)
         - Tools to configure the CI (part:ci)
+        - Tools to configure pytest (part:pytest)
     validations:
       required: true
   - type: textarea

--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -27,3 +27,4 @@ labelMappings:
   "part:model-only": "part:model-only"
   "part:nox": "part:nox"
   "part:protobuf": "part:protobuf"
+  "part:pytest": "part:pytest"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -69,3 +69,9 @@
       - "src/frequenz/repo/config/protobuf*"
     all:
       - "!tests*/**"
+
+"part:pytest":
+  - any:
+      - "src/frequenz/repo/config/pytest"
+    all:
+      - "!tests*/**"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ exclude CODEOWNERS
 exclude CONTRIBUTING.md
 exclude mkdocs.yml
 exclude noxfile.py
+exclude src/conftest.py
 recursive-exclude .github *
 recursive-exclude cookiecutter *
 recursive-exclude docs *

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ directory will be created with the generated project name. For example:
 cd ~/devel
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
     --directory=cookiecutter \
-    --checkout v0.4.0
+    --checkout v0.5.0
 ```
 
 This command will prompt you for the project type, name, and other

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,12 @@
 
 ## New Features
 
+- Add support for linting code examples found in *docstrings*.
+
+  A new module `frequenz.repo.config.pytest.examples` is added with an utility function to be able to easily collect and lint code examples in *docstrings*.
+
+  There is also a new optional dependency `extra-lint-examples` to easily pull the dependencies needed to do this linting. Please have a look at the documentation in the `frequenz.repo.config` package for more details.
+
 ### Cookiecutter template
 
 - Add a new GitHub workflow to check that release notes were updated.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This release adds linting of code examples in *docstrings*, a workflow to check if PRs have updated the release notes and an [editorconfig](https://editorconfig.org/) file, as well as a bunch of bug fixes.
 
 ## Upgrading
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,6 +58,14 @@
 
 - Add an `.editorconfig` file to ensure a common basic editor configuration for different file types.
 
+- Add a `pytest` hook to collect and lint code examples found in *docstrings* using `pylint`.
+
+  Examples found in code *docstrings* in the `src/` directory will now be collected and checked using `pylint`. This is done via the file `src/conftest.py`, which hooks into `pytest`, so to only check the examples you can run `pylint src`.
+
+  !!! info
+
+      There is a bug in the library used to extract the examples that prevents from collecting examples from `__init__.py` files. See https://github.com/frequenz-floss/frequenz-repo-config-python/issues/113 for more details.
+
 ## Bug Fixes
 
 - The distribution package doesn't include tests and other useless files anymore.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/MANIFEST.in
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/MANIFEST.in
@@ -9,6 +9,7 @@ exclude CODEOWNERS
 exclude CONTRIBUTING.md
 exclude mkdocs.yml
 exclude noxfile.py
+exclude src/conftest.py
 recursive-exclude .github *
 recursive-exclude docs *
 {%- if cookiecutter.type == "api" %}

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 67.7.2",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.4.0",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -70,7 +70,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.16",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.4.0",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.0",
 ]
 dev-mypy = [
   "mypy == 1.2.0",
@@ -79,7 +79,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.4.0",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.0",
 ]
 dev-pylint = [
   "pylint == 2.17.3",

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -86,16 +86,15 @@ dev-pylint = [
   # For checking the noxfile, docs/ script, and tests
   "{{cookiecutter.pypi_package_name}}[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-{%- if cookiecutter.type == "api" %}
-dev-pytest = ["pytest == 7.3.1"]
-{%- else %}
 dev-pytest = [
   "pytest == 7.3.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.0",
+{%- if cookiecutter.type != "api" %}
   "pytest-mock == 3.10.0",
   "pytest-asyncio == 0.21.0",
   "async-solipsism == 0.5",
-]
 {%- endif %}
+]
 dev = [
   "{{cookiecutter.pypi_package_name}}[dev-mkdocs,dev-docstrings,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",
 ]
@@ -138,7 +137,7 @@ disable = [
 
 [tool.pytest.ini_options]
 {%- if cookiecutter.type != "api" %}
-testpaths = ["tests"]
+testpaths = ["tests", "src"]
 asyncio_mode = "auto"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 {%- else %}
@@ -147,7 +146,7 @@ testpaths = ["pytests"]
 {%- if cookiecutter.type != "api" %}
 
 [[tool.mypy.overrides]]
-module = ["async_solipsism", "async_solipsism.*"]
+module = ["async_solipsism", "async_solipsism.*", "sybil", "sybil.*"]
 ignore_missing_imports = true
 {%- endif %}
 {%- if cookiecutter.type == "api" %}

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/src/conftest.py
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/src/conftest.py
@@ -1,0 +1,13 @@
+# License: {{cookiecutter.license}}
+# Copyright © {% now 'utc', '%Y' %} {{cookiecutter.author_name}}
+
+"""Validate docstring code examples.
+
+Code examples are often wrapped in triple backticks (```) within docstrings.
+This plugin extracts these code examples and validates them using pylint.
+"""
+
+from frequenz.repo.config.pytest import examples
+from sybil import Sybil
+
+pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Then simply run [Cookiecutter] where you want to create the new project:
 
 ```sh
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
-    --directory=cookiecutter --checkout v0.4.0
+    --directory=cookiecutter --checkout v0.5.0
 ```
 
 This command will prompt you for the project type, name, and other

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ plugins:
             - https://nox.thea.codes/en/stable/objects.inv
             - https://oprypin.github.io/mkdocs-gen-files/objects.inv
             - https://setuptools.pypa.io/en/latest/objects.inv
+            - https://sybil.readthedocs.io/en/stable/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
   - section-index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,13 +83,15 @@ dev-mypy = [
 ]
 dev-noxfile = ["nox == 2023.4.22"]
 dev-pylint = [
-  "pylint == 2.17.3",
+  # dev-pytest already defines a dependency to pylint because of the examples
   # For checking the noxfile, docs/ script, and tests
   "frequenz-repo-config[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
 dev-pytest = [
-  "pytest == 7.3.1",
+  "pytest == 7.4.0",
+  "pylint == 2.17.3",      # We need this to check for the examples
   "cookiecutter == 2.1.1", # For checking the cookiecutter scripts
+  "sybil == 5.0.3",        # Should be consistent with the extra-lint-examples dependency
 ]
 dev = [
   "frequenz-repo-config[dev-mkdocs,dev-docstrings,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",
@@ -133,7 +135,7 @@ module = ["cookiecutter", "cookiecutter.*", "sybil", "sybil.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["src", "tests"]
 markers = [
   "integration: integration tests (deselect with '-m \"not integration\"')",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,11 @@ api = [
 app = []
 lib = []
 model = []
+extra-lint-examples = [
+  "pylint >= 2.17.3, < 3",
+  "pytest >= 7.3.0, < 8",
+  "sybil >= 5.0.3, < 6",
+]
 dev-docstrings = [
   "pydocstyle == 6.3.0",
   "darglint == 1.8.1",
@@ -124,7 +129,7 @@ disable = [
 ]
 
 [[tool.mypy.overrides]]
-module = ["cookiecutter", "cookiecutter.*"]
+module = ["cookiecutter", "cookiecutter.*", "sybil", "sybil.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,14 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Validate docstring code examples.
+
+Code examples are often wrapped in triple backticks (```) within docstrings.
+This plugin extracts these code examples and validates them using pylint.
+"""
+
+from sybil import Sybil
+
+from frequenz.repo.config.pytest import examples
+
+pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -286,7 +286,7 @@ dependencies to your project, for example:
 requires = [
   "setuptools >= 67.3.2, < 68",
   "setuptools_scm[toml] >= 7.1.0, < 8",
-  "frequenz-repo-config[api] >= 0.3.0, < 0.4.0",
+  "frequenz-repo-config[api] >= 0.5.0, < 0.6.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -207,6 +207,77 @@ plugins:
         - path/to/my/custom/script.py
 ```
 
+## `pytest` (running tests)
+
+### Linting examples in the source code's *docstrings*
+
+To make sure the examples included in your source code's *docstrings* are valid, you can
+use [`pytest`](https://pypi.org/project/pytest/) to automatically collect all the
+examples wrapped in triple backticks (````python`) within our docstrings and validate
+them using [`pylint`](https://pypi.org/project/pylint/).
+
+To do so there is some setup that's needed:
+
+1. Add a `conftest.py` file to the root directory containing your source code with the
+   following contents:
+
+    ```python
+    from frequenz.repo.config.pytest import examples
+    from sybil import Sybil
+
+    pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()
+    ```
+
+    Unfortunately, because of how Sybil works, the [`Sybil`][sybil.Sybil] class needs to
+    be instantiated in the `conftest.py` file. To easily do this, the convenience
+    function
+    [`get_sybil_arguments()`][frequenz.repo.config.pytest.examples.get_sybil_arguments]
+    is provided to get the arguments to pass to the `Sybil()` constructor to be able to
+    collect and lint the examples.
+
+2. Add the following configuration to your `pyproject.toml` file (see
+   the [`nox` section](#pyprojecttoml-configuration) for details on how to configure
+   dependencies to play nicely with `nox`):
+
+    ```toml
+    [project.optional-dependencies]
+    # ...
+    dev-pytest = [
+        # ...
+        "frequenz-repo-config[extra-lint-examples] == 0.5.0",
+    ]
+    # ...
+    [[tool.mypy.overrides]]
+    module = [
+        # ...
+        "sybil",
+        "sybil.*",
+    ]
+    ignore_missing_imports = true
+    # ...
+    [tool.pytest.ini_options]
+    testpaths = [
+        # ...
+        "src",
+    ]
+    ```
+
+   This will make sure that you have the appropriate dependencies installed to run the
+   the tests linting and that `mypy` doesn't complain about the `sybil` module not being
+   typed.
+
+3. Exclude the `src/conftest.py` file from the distribution package, as it shouldn't be
+   shipped with the code, it is only for delelopment purposes. To do so, add the
+   following line to the `MANIFEST.in` file:
+
+    ```
+    # ...
+    exclude src/conftest.py
+    ```
+
+Now you should be able to run `nox -s pytest` (or `pytest` directly) and see the tests
+linting the examples in your code's *docstrings*.
+
 # APIs
 
 ## Protobuf configuation

--- a/src/frequenz/repo/config/mkdocs.py
+++ b/src/frequenz/repo/config/mkdocs.py
@@ -35,7 +35,9 @@ def _is_internal(path_parts: Tuple[str, ...]) -> bool:
     def with_underscore_not_init(part: str) -> bool:
         return part.startswith("_") and part != "__init__"
 
-    return any(p for p in path_parts if with_underscore_not_init(p))
+    is_conftest = len(path_parts) == 1 and path_parts[0] == "conftest"
+
+    return is_conftest or any(p for p in path_parts if with_underscore_not_init(p))
 
 
 def generate_python_api_pages(

--- a/src/frequenz/repo/config/pytest/__init__.py
+++ b/src/frequenz/repo/config/pytest/__init__.py
@@ -1,0 +1,12 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Pytest utilities.
+
+This package contains utilities for testing with [`pytest`](https://pypi.org/project/pytest/).
+
+The following modules are available:
+
+- [`examples`][frequenz.repo.config.pytest.examples]: Utilities to enable linting of
+  code examples in docstrings.
+"""

--- a/src/frequenz/repo/config/pytest/examples.py
+++ b/src/frequenz/repo/config/pytest/examples.py
@@ -1,0 +1,234 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Utility to enable linting of code examples in docstrings.
+
+Code examples are often wrapped in triple backticks (````python`) within our docstrings.
+This plugin extracts these code examples and validates them using pylint.
+
+The main utility function is
+[`get_sybil_arguments()`][frequenz.repo.config.pytest.examples.get_sybil_arguments],
+which returns a dictionary that can be used to pass to the [`Sybil()`][sybil.Sybil]
+constructor.
+
+You still need to create a `conftest.py` file in the root of your project's sources,
+typically `src/conftest.py`, with the following contents:
+
+```python
+from frequenz.repo.config.pytest import examples
+from sybil import Sybil
+
+pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()
+```
+"""
+
+import ast
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from sybil import Example
+from sybil.evaluators.python import pad
+from sybil.parsers.abstract.lexers import textwrap
+from sybil.parsers.myst import CodeBlockParser
+
+_PYLINT_DISABLE_COMMENT = (
+    "# pylint: {}=unused-import,wildcard-import,unused-wildcard-import"
+)
+
+_FORMAT_STRING = """
+# Generated auto-imports for code example
+{disable_pylint}
+{imports}
+{enable_pylint}
+
+{code}"""
+
+
+def get_sybil_arguments() -> dict[str, Any]:
+    """Get the arguments to pass when instantiating the Sybil object to lint docs examples.
+
+    Returns:
+        The arguments to pass when instantiating the Sybil object.
+    """
+    return {
+        "parsers": [_CustomPythonCodeBlockParser()],
+        "patterns": ["*.py"],
+    }
+
+
+def _get_import_statements(code: str) -> list[str]:
+    """Get all import statements from a given code string.
+
+    Args:
+        code: The code to extract import statements from.
+
+    Returns:
+        A list of import statements.
+    """
+    tree = ast.parse(code)
+    import_statements: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            import_statement = ast.get_source_segment(code, node)
+            assert import_statement is not None
+            import_statements.append(import_statement)
+
+    return import_statements
+
+
+def _path_to_import_statement(path: Path) -> str:
+    """Convert a path to a Python file to an import statement.
+
+    Args:
+        path: The path to convert.
+
+    Returns:
+        The import statement.
+
+    Raises:
+        ValueError: If the path does not point to a Python file.
+    """
+    # Make the path relative to the present working directory
+    if path.is_absolute():
+        path = path.relative_to(Path.cwd())
+
+    # Check if the path is a Python file
+    if path.suffix != ".py":
+        raise ValueError("Path must point to a Python file (.py)")
+
+    # Remove 'src' prefix if present
+    parts = path.parts
+    if parts[0] == "src":
+        parts = parts[1:]
+
+    # Remove the '.py' extension and join parts with '.'
+    module_path = ".".join(parts)[:-3]
+
+    # Create the import statement
+    import_statement = f"from {module_path} import *"
+    return import_statement
+
+
+# We need to add the type ignore comment here because the Sybil library does not
+# have type annotations.
+class _CustomPythonCodeBlockParser(CodeBlockParser):  # type: ignore[misc]
+    """Code block parser that validates extracted code examples using pylint.
+
+    This parser is a modified version of the default Python code block parser
+    from the Sybil library.
+    It uses pylint to validate the extracted code examples.
+
+    All code examples are preceded by the original file's import statements as
+    well as an wildcard import of the file itself.
+    This allows us to use the code examples as if they were part of the original
+    file.
+
+    Additionally, the code example is padded with empty lines to make sure the
+    line numbers are correct.
+
+    Pylint warnings which are unimportant for code examples are disabled.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the parser."""
+        super().__init__("python")
+
+    def evaluate(self, example: Example) -> None | str:
+        """Validate the extracted code example using pylint.
+
+        Args:
+            example: The extracted code example.
+
+        Returns:
+            None if the code example is valid, otherwise the pylint output.
+        """
+        # Get the import statements for the original file
+        import_header = _get_import_statements(example.document.text)
+        # Add a wildcard import of the original file
+        import_header.append(
+            _path_to_import_statement(Path(os.path.relpath(example.path)))
+        )
+        imports_code = "\n".join(import_header)
+
+        # Dedent the code example
+        # There is also example.parsed that is already prepared, but it has
+        # empty lines stripped and thus fucks up the line numbers.
+        example_code = textwrap.dedent(
+            example.document.text[example.start : example.end]
+        )
+        # Remove first line (the line with the triple backticks)
+        example_code = example_code[example_code.find("\n") + 1 :]
+
+        example_with_imports = _FORMAT_STRING.format(
+            disable_pylint=_PYLINT_DISABLE_COMMENT.format("disable"),
+            imports=imports_code,
+            enable_pylint=_PYLINT_DISABLE_COMMENT.format("enable"),
+            code=example_code,
+        )
+
+        # Make sure the line numbers are correct
+        source = pad(
+            example_with_imports,
+            example.line - imports_code.count("\n") - _FORMAT_STRING.count("\n"),
+        )
+
+        # pylint disable parameters
+        pylint_disable_params = [
+            "missing-module-docstring",
+            "missing-class-docstring",
+            "missing-function-docstring",
+            "reimported",
+            "unused-variable",
+            "no-name-in-module",
+            "await-outside-async",
+        ]
+
+        response = _validate_with_pylint(source, example.path, pylint_disable_params)
+
+        if len(response) > 0:
+            return (
+                f"Pylint validation failed for code example:\n"
+                f"{example_with_imports}\nOutput: " + "\n".join(response)
+            )
+
+        return None
+
+
+def _validate_with_pylint(
+    code_example: str, path: str, disable_params: list[str]
+) -> list[str]:
+    """Validate a code example using pylint.
+
+    Args:
+        code_example: The code example to validate.
+        path: The path to the original file.
+        disable_params: The pylint disable parameters.
+
+    Returns:
+        A list of pylint messages.
+    """
+    try:
+        pylint_command = [
+            "pylint",
+            "--disable",
+            ",".join(disable_params),
+            "--from-stdin",
+            path,
+        ]
+
+        subprocess.run(
+            pylint_command,
+            input=code_example,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exception:
+        output = exception.output
+        assert isinstance(output, str)
+        return output.splitlines()
+
+    return []

--- a/src/frequenz/repo/config/pytest/examples.py
+++ b/src/frequenz/repo/config/pytest/examples.py
@@ -55,6 +55,10 @@ def get_sybil_arguments() -> dict[str, Any]:
     return {
         "parsers": [_CustomPythonCodeBlockParser()],
         "patterns": ["*.py"],
+        # This is a hack because Sybil seems to have issues with `__init__.py` files.
+        # See https://github.com/frequenz-floss/frequenz-repo-config-python/issues/113
+        # for details
+        "excludes": ["__init__.py"],
     }
 
 

--- a/tests/integration/test_cookiecutter_generation.py
+++ b/tests/integration/test_cookiecutter_generation.py
@@ -283,12 +283,8 @@ def _update_pyproject_repo_config_dep(
         repo_type: Type of the repo to generate.
         repo_path: Path to the generated repo.
     """
-    repo_config_dep = (
-        f"frequenz-repo-config[{repo_type.value}] @ file://{repo_config_path}"
-    )
-    repo_config_dep_re = re.compile(
-        rf"""frequenz-repo-config\[{repo_type.value}\][^"]+"""
-    )
+    repo_config_dep = rf"frequenz-repo-config[\1] @ file://{repo_config_path}"
+    repo_config_dep_re = re.compile(r"""frequenz-repo-config\[([^]]+)\][^"]+""")
 
     with open(repo_path / "pyproject.toml", encoding="utf8") as pyproject_file:
         pyproject_content = pyproject_file.read()

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -19,6 +19,6 @@ def test_optional_dependencies() -> None:
     defined = {
         k
         for k in pyproject_toml["project"]["optional-dependencies"].keys()
-        if k != "dev" and not k.startswith("dev-")
+        if k != "dev" and not k.startswith("dev-") and not k.startswith("extra-")
     }
     assert defined == expected, utils.MSG_UNEXPECTED_REPO_TYPES

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/MANIFEST.in
@@ -6,6 +6,7 @@ exclude CODEOWNERS
 exclude CONTRIBUTING.md
 exclude mkdocs.yml
 exclude noxfile.py
+exclude src/conftest.py
 recursive-exclude .github *
 recursive-exclude docs *
 recursive-exclude tests *

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -70,6 +70,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.3.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.0",
   "pytest-mock == 3.10.0",
   "pytest-asyncio == 0.21.0",
   "async-solipsism == 0.5",
@@ -112,12 +113,12 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "src"]
 asyncio_mode = "auto"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 
 [[tool.mypy.overrides]]
-module = ["async_solipsism", "async_solipsism.*"]
+module = ["async_solipsism", "async_solipsism.*", "sybil", "sybil.*"]
 ignore_missing_imports = true
 
 [tool.setuptools_scm]

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 67.7.2",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[actor] == 0.4.0",
+  "frequenz-repo-config[actor] == 0.5.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -52,7 +52,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.16",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[actor] == 0.4.0",
+  "frequenz-repo-config[actor] == 0.5.0",
 ]
 dev-mypy = [
   "mypy == 1.2.0",
@@ -61,7 +61,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[actor] == 0.4.0",
+  "frequenz-repo-config[actor] == 0.5.0",
 ]
 dev-pylint = [
   "pylint == 2.17.3",

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/src/conftest.py
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/src/conftest.py
@@ -1,0 +1,13 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Validate docstring code examples.
+
+Code examples are often wrapped in triple backticks (```) within docstrings.
+This plugin extracts these code examples and validates them using pylint.
+"""
+
+from frequenz.repo.config.pytest import examples
+from sybil import Sybil
+
+pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/MANIFEST.in
@@ -7,6 +7,7 @@ exclude CODEOWNERS
 exclude CONTRIBUTING.md
 exclude mkdocs.yml
 exclude noxfile.py
+exclude src/conftest.py
 recursive-exclude .github *
 recursive-exclude docs *
 recursive-exclude pytests *

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/py/conftest.py
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/py/conftest.py
@@ -1,0 +1,13 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Validate docstring code examples.
+
+Code examples are often wrapped in triple backticks (```) within docstrings.
+This plugin extracts these code examples and validates them using pylint.
+"""
+
+from frequenz.repo.config.pytest import examples
+from sybil import Sybil
+
+pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -66,7 +66,10 @@ dev-pylint = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-test[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-pytest = ["pytest == 7.3.1"]
+dev-pytest = [
+  "pytest == 7.3.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.0",
+]
 dev = [
   "frequenz-api-test[dev-mkdocs,dev-docstrings,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 67.7.2",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[api] == 0.4.0",
+  "frequenz-repo-config[api] == 0.5.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -50,7 +50,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.16",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[api] == 0.4.0",
+  "frequenz-repo-config[api] == 0.5.0",
 ]
 dev-mypy = [
   "mypy == 1.2.0",
@@ -59,7 +59,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[api] == 0.4.0",
+  "frequenz-repo-config[api] == 0.5.0",
 ]
 dev-pylint = [
   "pylint == 2.17.3",

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/MANIFEST.in
@@ -6,6 +6,7 @@ exclude CODEOWNERS
 exclude CONTRIBUTING.md
 exclude mkdocs.yml
 exclude noxfile.py
+exclude src/conftest.py
 recursive-exclude .github *
 recursive-exclude docs *
 recursive-exclude tests *

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -69,6 +69,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.3.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.0",
   "pytest-mock == 3.10.0",
   "pytest-asyncio == 0.21.0",
   "async-solipsism == 0.5",
@@ -111,12 +112,12 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "src"]
 asyncio_mode = "auto"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 
 [[tool.mypy.overrides]]
-module = ["async_solipsism", "async_solipsism.*"]
+module = ["async_solipsism", "async_solipsism.*", "sybil", "sybil.*"]
 ignore_missing_imports = true
 
 [tool.setuptools_scm]

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 67.7.2",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[app] == 0.4.0",
+  "frequenz-repo-config[app] == 0.5.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -51,7 +51,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.16",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[app] == 0.4.0",
+  "frequenz-repo-config[app] == 0.5.0",
 ]
 dev-mypy = [
   "mypy == 1.2.0",
@@ -60,7 +60,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[app] == 0.4.0",
+  "frequenz-repo-config[app] == 0.5.0",
 ]
 dev-pylint = [
   "pylint == 2.17.3",

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/src/conftest.py
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/src/conftest.py
@@ -1,0 +1,13 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Validate docstring code examples.
+
+Code examples are often wrapped in triple backticks (```) within docstrings.
+This plugin extracts these code examples and validates them using pylint.
+"""
+
+from frequenz.repo.config.pytest import examples
+from sybil import Sybil
+
+pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/MANIFEST.in
@@ -6,6 +6,7 @@ exclude CODEOWNERS
 exclude CONTRIBUTING.md
 exclude mkdocs.yml
 exclude noxfile.py
+exclude src/conftest.py
 recursive-exclude .github *
 recursive-exclude docs *
 recursive-exclude tests *

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 67.7.2",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[lib] == 0.4.0",
+  "frequenz-repo-config[lib] == 0.5.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -48,7 +48,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.16",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[lib] == 0.4.0",
+  "frequenz-repo-config[lib] == 0.5.0",
 ]
 dev-mypy = [
   "mypy == 1.2.0",
@@ -57,7 +57,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[lib] == 0.4.0",
+  "frequenz-repo-config[lib] == 0.5.0",
 ]
 dev-pylint = [
   "pylint == 2.17.3",

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -66,6 +66,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.3.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.0",
   "pytest-mock == 3.10.0",
   "pytest-asyncio == 0.21.0",
   "async-solipsism == 0.5",
@@ -108,12 +109,12 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "src"]
 asyncio_mode = "auto"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 
 [[tool.mypy.overrides]]
-module = ["async_solipsism", "async_solipsism.*"]
+module = ["async_solipsism", "async_solipsism.*", "sybil", "sybil.*"]
 ignore_missing_imports = true
 
 [tool.setuptools_scm]

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/src/conftest.py
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/src/conftest.py
@@ -1,0 +1,13 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Validate docstring code examples.
+
+Code examples are often wrapped in triple backticks (```) within docstrings.
+This plugin extracts these code examples and validates them using pylint.
+"""
+
+from frequenz.repo.config.pytest import examples
+from sybil import Sybil
+
+pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/MANIFEST.in
@@ -6,6 +6,7 @@ exclude CODEOWNERS
 exclude CONTRIBUTING.md
 exclude mkdocs.yml
 exclude noxfile.py
+exclude src/conftest.py
 recursive-exclude .github *
 recursive-exclude docs *
 recursive-exclude tests *

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -70,6 +70,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.3.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.0",
   "pytest-mock == 3.10.0",
   "pytest-asyncio == 0.21.0",
   "async-solipsism == 0.5",
@@ -112,12 +113,12 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "src"]
 asyncio_mode = "auto"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 
 [[tool.mypy.overrides]]
-module = ["async_solipsism", "async_solipsism.*"]
+module = ["async_solipsism", "async_solipsism.*", "sybil", "sybil.*"]
 ignore_missing_imports = true
 
 [tool.setuptools_scm]

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 67.7.2",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[model] == 0.4.0",
+  "frequenz-repo-config[model] == 0.5.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -52,7 +52,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.16",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[model] == 0.4.0",
+  "frequenz-repo-config[model] == 0.5.0",
 ]
 dev-mypy = [
   "mypy == 1.2.0",
@@ -61,7 +61,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[model] == 0.4.0",
+  "frequenz-repo-config[model] == 0.5.0",
 ]
 dev-pylint = [
   "pylint == 2.17.3",

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/src/conftest.py
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/src/conftest.py
@@ -1,0 +1,13 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Validate docstring code examples.
+
+Code examples are often wrapped in triple backticks (```) within docstrings.
+This plugin extracts these code examples and validates them using pylint.
+"""
+
+from frequenz.repo.config.pytest import examples
+from sybil import Sybil
+
+pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()


### PR DESCRIPTION
Also prepare for the v0.5.0 release.

- Update repo-config version
- Add support for linting code examples in docstrings
- Add support for the `part:pytest` label
- mkdocs: Ignore the top-level `conftest` module
- Lint docstrings examples
- Skip examples linting for `__init__.py` files
- cookiecutter: Add a `pytest` hook to lint docstring examples
- Add summary to release notes

Fixes #27.
