### PR TITLE
Properly label `conftest.py` files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,7 @@
       - "!tests*/**"
 
 "part:tests":
+  - "**/conftest.py"
   - "tests*/**"
 
 "part:tooling":
@@ -24,6 +25,7 @@
       - "**/*.toml"
       - "**/*.yaml"
       - "**/*.yml"
+      - "**/conftest.py"
       - ".editorconfig"
       - ".git*"
       - ".git*/**"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,4 +31,4 @@
 
 ### Cookiecutter template
 
-<!-- Here bug fixes for cookiecutter specifically -->
+- Properly label `conftest.py` files.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/labeler.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/labeler.yml
@@ -33,6 +33,7 @@
   - LICENSE
 
 "part:tests":
+  - "**/conftest.py"
 {%- if cookiecutter.type == "api" %}
   - "pytests/**"
 {%- else %}
@@ -44,6 +45,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - "**/conftest.py"
   - ".editorconfig"
   - ".git*"
   - ".git*/**"

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/labeler.yml
@@ -33,6 +33,7 @@
   - LICENSE
 
 "part:tests":
+  - "**/conftest.py"
   - "tests/**"
 
 "part:tooling":
@@ -40,6 +41,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - "**/conftest.py"
   - ".editorconfig"
   - ".git*"
   - ".git*/**"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/labeler.yml
@@ -33,6 +33,7 @@
   - LICENSE
 
 "part:tests":
+  - "**/conftest.py"
   - "pytests/**"
 
 "part:tooling":
@@ -40,6 +41,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - "**/conftest.py"
   - ".editorconfig"
   - ".git*"
   - ".git*/**"

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/labeler.yml
@@ -33,6 +33,7 @@
   - LICENSE
 
 "part:tests":
+  - "**/conftest.py"
   - "tests/**"
 
 "part:tooling":
@@ -40,6 +41,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - "**/conftest.py"
   - ".editorconfig"
   - ".git*"
   - ".git*/**"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/labeler.yml
@@ -33,6 +33,7 @@
   - LICENSE
 
 "part:tests":
+  - "**/conftest.py"
   - "tests/**"
 
 "part:tooling":
@@ -40,6 +41,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - "**/conftest.py"
   - ".editorconfig"
   - ".git*"
   - ".git*/**"

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/labeler.yml
@@ -33,6 +33,7 @@
   - LICENSE
 
 "part:tests":
+  - "**/conftest.py"
   - "tests/**"
 
 "part:tooling":
@@ -40,6 +41,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - "**/conftest.py"
   - ".editorconfig"
   - ".git*"
   - ".git*/**"


### PR DESCRIPTION
These files are not really regular sources, but part of the test tooling.
