### PR TITLE
API: Add cross-linking to common-api and prepare for the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ directory will be created with the generated project name. For example:
 cd ~/devel
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
     --directory=cookiecutter \
-    --checkout v0.5.1
+    --checkout v0.5.2
 ```
 
 This command will prompt you for the project type, name, and other

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This version focus on some bug fixes and final polishing of v0.5.x.
 
 ## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ### Cookiecutter template
 
@@ -15,8 +13,6 @@
 - If your replay file contains a long `Introduction` key, you can replace it with an empty string (`""`), it doesn't need to have any particular content and it increases the size and noise in the replay file.
 
 ## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ### Cookiecutter template
 
@@ -43,8 +39,6 @@
 - API: The common-api documentation now is cross-linked.
 
 ## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
 
 ### Cookiecutter template
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,7 +20,6 @@
 
 ### Cookiecutter template
 
-
 - Generated project's dependencies were bumped.
 
 - Move `TODO`s so they are in their own line.
@@ -40,6 +39,8 @@
 - Add a `\n` to the end of the replay file.
 
   This is just to be nice to most editors and text files conventions, that likes it more if there is a `\n` at the end of the file.
+
+- API: The common-api documentation now is cross-linked.
 
 ## Bug Fixes
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             - https://frequenz-floss.github.io/frequenz-channels-python/v0.14/objects.inv
             - https://frequenz-floss.github.io/frequenz-sdk-python/v0.22/objects.inv
 {%- elif cookiecutter.type == "api" %}
+            - https://frequenz-floss.github.io/frequenz-api-common/v0.3/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
 {%- endif %}
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.1",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -73,7 +73,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.1",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -82,7 +82,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.1",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -91,7 +91,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
 {%- if cookiecutter.type != "api" %}
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Then simply run [Cookiecutter] where you want to create the new project:
 
 ```sh
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
-    --directory=cookiecutter --checkout v0.5.1
+    --directory=cookiecutter --checkout v0.5.2
 ```
 
 This command will prompt you for the project type, name, and other
@@ -238,7 +238,7 @@ the files in your existing project by using `rsync` or similar tools:
 ```sh
 cd /tmp
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
-    --directory=cookiecutter --checkout v0.5.1
+    --directory=cookiecutter --checkout v0.5.2
 rsync -vr --exclude=.git/ new-project/ /path/to/existing/project
 cd /path/to/existing/project
 git diff
@@ -283,7 +283,7 @@ git commit -a  # commit all changes
 cd ..
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
     --directory=cookiecutter \
-    --checkout v0.5.1 \
+    --checkout v0.5.2 \
     --overwrite-if-exists \
     --replay \
     --replay-file project-directory/.cookiecutter-replay.json

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -244,7 +244,7 @@ To do so there is some setup that's needed:
     # ...
     dev-pytest = [
         # ...
-        "frequenz-repo-config[extra-lint-examples] == 0.5.1",
+        "frequenz-repo-config[extra-lint-examples] == 0.5.2",
     ]
     # ...
     [[tool.mypy.overrides]]
@@ -357,7 +357,7 @@ dependencies to your project, for example:
 requires = [
   "setuptools >= 67.3.2, < 68",
   "setuptools_scm[toml] >= 7.1.0, < 8",
-  "frequenz-repo-config[api] >= 0.5.1, < 0.6.0",
+  "frequenz-repo-config[api] >= 0.5.2, < 0.6.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[actor] == 0.5.1",
+  "frequenz-repo-config[actor] == 0.5.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -55,7 +55,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[actor] == 0.5.1",
+  "frequenz-repo-config[actor] == 0.5.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -64,7 +64,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[actor] == 0.5.1",
+  "frequenz-repo-config[actor] == 0.5.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -73,7 +73,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",
   "async-solipsism == 0.5",

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
@@ -110,6 +110,7 @@ plugins:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
+            - https://frequenz-floss.github.io/frequenz-api-common/v0.3/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[api] == 0.5.1",
+  "frequenz-repo-config[api] == 0.5.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -53,7 +53,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[api] == 0.5.1",
+  "frequenz-repo-config[api] == 0.5.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -62,7 +62,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[api] == 0.5.1",
+  "frequenz-repo-config[api] == 0.5.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -71,7 +71,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
 ]
 dev = [
   "frequenz-api-test[dev-mkdocs,dev-docstrings,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[app] == 0.5.1",
+  "frequenz-repo-config[app] == 0.5.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -54,7 +54,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[app] == 0.5.1",
+  "frequenz-repo-config[app] == 0.5.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -63,7 +63,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[app] == 0.5.1",
+  "frequenz-repo-config[app] == 0.5.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -72,7 +72,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",
   "async-solipsism == 0.5",

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[lib] == 0.5.1",
+  "frequenz-repo-config[lib] == 0.5.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -51,7 +51,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[lib] == 0.5.1",
+  "frequenz-repo-config[lib] == 0.5.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -60,7 +60,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[lib] == 0.5.1",
+  "frequenz-repo-config[lib] == 0.5.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -69,7 +69,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",
   "async-solipsism == 0.5",

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[model] == 0.5.1",
+  "frequenz-repo-config[model] == 0.5.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -55,7 +55,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[model] == 0.5.1",
+  "frequenz-repo-config[model] == 0.5.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -64,7 +64,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[model] == 0.5.1",
+  "frequenz-repo-config[model] == 0.5.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -73,7 +73,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",
   "async-solipsism == 0.5",


### PR DESCRIPTION
Now that we depend on common-api v0.3.x+ we can cross-link the documentation.
