### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
     versioning-strategy: auto
     # Allow up to 10 open pull requests for updates to dependency versions
     open-pull-requests-limit: 10
+    # Group production and development (required and optional in the context of
+    # pyproject.toml) dependency updates when they are patch and minor updates,
+    # so we end up with less PRs being generated.
+    # Major updates are still managed, but they'll create one PR per
+    # dependency, as major updates are expected to be breaking, it is better to
+    # manage them individually.
+    grups:
+      required:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      optional:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,7 +18,7 @@
 
 ### Cookiecutter template
 
-<!-- Here new features for cookiecutter specifically -->
+- Now dependabot updates will be done weekly and grouped by *required* and *optional* for minor and patch updates (major updates are still done individually for each dependency).
 
 ## Bug Fixes
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
     versioning-strategy: auto
     # Allow up to 10 open pull requests for updates to dependency versions
     open-pull-requests-limit: 10
+    # We group production and development ("optional" in the context of
+    # pyproject.toml) dependency updates when they are patch and minor updates,
+    # so we end up with less PRs being generated.
+    # Major updates are still managed, but they'll create one PR per
+    # dependency, as major updates are expected to be breaking, it is better to
+    # manage them individually.
+    grups:
+      required:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      optional:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "06:00"
     labels:
       - "part:tooling"
@@ -35,10 +35,8 @@ updates:
     # + `allow` one doesn't seem to work.
     ignore:
       - dependency-name: "submodules/frequenz-api-common"
-    # The google api common repo changes very seldom, so there is no need to
-    # check very often.
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/src/frequenz/repo/config/nox/__init__.py
+++ b/src/frequenz/repo/config/nox/__init__.py
@@ -33,8 +33,8 @@ config.opts.black.append("--diff")
 nox.configure(config)
 ```
 
-If you need further customization or to define new sessions, you can use the following
-modules:
+If you need further customization or to define new sessions, you can use the
+following modules:
 
 - [`frequenz.repo.config.nox.config`][]: Low-level utilities to configure nox sessions.
   It defines the `Config` and CommandsOptions` classes and the actual implementation of

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
     versioning-strategy: auto
     # Allow up to 10 open pull requests for updates to dependency versions
     open-pull-requests-limit: 10
+    # We group production and development ("optional" in the context of
+    # pyproject.toml) dependency updates when they are patch and minor updates,
+    # so we end up with less PRs being generated.
+    # Major updates are still managed, but they'll create one PR per
+    # dependency, as major updates are expected to be breaking, it is better to
+    # manage them individually.
+    grups:
+      required:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      optional:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
     versioning-strategy: auto
     # Allow up to 10 open pull requests for updates to dependency versions
     open-pull-requests-limit: 10
+    # We group production and development ("optional" in the context of
+    # pyproject.toml) dependency updates when they are patch and minor updates,
+    # so we end up with less PRs being generated.
+    # Major updates are still managed, but they'll create one PR per
+    # dependency, as major updates are expected to be breaking, it is better to
+    # manage them individually.
+    grups:
+      required:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      optional:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "06:00"
     labels:
       - "part:tooling"
@@ -34,10 +34,8 @@ updates:
     # + `allow` one doesn't seem to work.
     ignore:
       - dependency-name: "submodules/frequenz-api-common"
-    # The google api common repo changes very seldom, so there is no need to
-    # check very often.
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
     versioning-strategy: auto
     # Allow up to 10 open pull requests for updates to dependency versions
     open-pull-requests-limit: 10
+    # We group production and development ("optional" in the context of
+    # pyproject.toml) dependency updates when they are patch and minor updates,
+    # so we end up with less PRs being generated.
+    # Major updates are still managed, but they'll create one PR per
+    # dependency, as major updates are expected to be breaking, it is better to
+    # manage them individually.
+    grups:
+      required:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      optional:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
     versioning-strategy: auto
     # Allow up to 10 open pull requests for updates to dependency versions
     open-pull-requests-limit: 10
+    # We group production and development ("optional" in the context of
+    # pyproject.toml) dependency updates when they are patch and minor updates,
+    # so we end up with less PRs being generated.
+    # Major updates are still managed, but they'll create one PR per
+    # dependency, as major updates are expected to be breaking, it is better to
+    # manage them individually.
+    grups:
+      required:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      optional:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
     versioning-strategy: auto
     # Allow up to 10 open pull requests for updates to dependency versions
     open-pull-requests-limit: 10
+    # We group production and development ("optional" in the context of
+    # pyproject.toml) dependency updates when they are patch and minor updates,
+    # so we end up with less PRs being generated.
+    # Major updates are still managed, but they'll create one PR per
+    # dependency, as major updates are expected to be breaking, it is better to
+    # manage them individually.
+    grups:
+      required:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      optional:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
We group production and development ("optional" in the context of `pyproject.toml`) dependency updates when they are patch and minor updates,so we end up with less PRs being generated.

Major updates are still managed, but they'll create one PR per dependency, as major updates are expected to be breaking, it is better to manage them individually.

Also change dependabot frequency to weekly, as security updates are handled separately, there is no urgency for having other updates so often.
