### PR TITLE
ci: Add env and pip debug information

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,17 @@ jobs:
           - ubuntu-20.04
         python:
           - "3.11"
+        nox-session:
+          # To speed things up a bit we use the special ci_checks_max session
+          # that uses the same venv to run multiple linting sessions
+          - "ci_checks_max"
+          - "pytest_min"
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Print environment (debug)
+        run: env
+
       - name: Fetch sources
         uses: actions/checkout@v3
         with:
@@ -50,11 +58,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev-noxfile]
+          pip freeze
+
+      - name: Create nox venv
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox --install-only -e "$NOX_SESSION"
+
+      - name: Print pip freeze for nox venv (debug)
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: |
+          . ".nox/$NOX_SESSION/bin/activate"
+          pip freeze
+          deactivate
 
       - name: Run nox
-        # To speed things up a bit we use the special ci_checks_max session
-        # that uses the same venv to run multiple linting sessions
-        run: nox -e ci_checks_max pytest_min
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox -R -e "$NOX_SESSION"
         timeout-minutes: 60
 
   build:
@@ -76,6 +98,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U build
+          pip freeze
 
       - name: Build the source and binary distribution
         run: python -m build
@@ -110,6 +133,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Generate the documentation
         env:
@@ -192,6 +216,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Fetch the gh-pages branch
         if: steps.mike-metadata.outputs.version

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,7 +18,12 @@
 
 ### Cookiecutter template
 
+
 - Now dependabot updates will be done weekly and grouped by *required* and *optional* for minor and patch updates (major updates are still done individually for each dependency).
+
+- ci: Add debug information when installing pip packages.
+
+  The output of `pip freeze` is printed to be able to more easily debug different behaviours between GitHub workflow runs and local runs.
 
 ## Bug Fixes
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -57,9 +57,17 @@ jobs:
           - ubuntu-20.04
         python:
           - "3.11"
+        nox-session:
+          # To speed things up a bit we use the special ci_checks_max session
+          # that uses the same venv to run multiple linting sessions
+          - "ci_checks_max"
+          - "pytest_min"
     runs-on: {{'${{ matrix.os }}'}}
 
     steps:
+      - name: Print environment (debug)
+        run: env
+
       - name: Fetch sources
         uses: actions/checkout@v3
         with:
@@ -75,11 +83,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev-noxfile]
+          pip freeze
+
+      - name: Create nox venv
+        env:
+          NOX_SESSION: {{'${{ matrix.nox-session }}'}}
+        run: nox --install-only -e "$NOX_SESSION"
+
+      - name: Print pip freeze for nox venv (debug)
+        env:
+          NOX_SESSION: {{'${{ matrix.nox-session }}'}}
+        run: |
+          . ".nox/$NOX_SESSION/bin/activate"
+          pip freeze
+          deactivate
 
       - name: Run nox
-        # To speed things up a bit we use the special ci_checks_max session
-        # that uses the same venv to run multiple linting sessions
-        run: nox -e ci_checks_max pytest_min
+        env:
+          NOX_SESSION: {{'${{ matrix.nox-session }}'}}
+        run: nox -R -e "$NOX_SESSION"
         timeout-minutes: 10
 
   build:
@@ -101,6 +123,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U build
+          pip freeze
 
       - name: Build the source and binary distribution
         run: python -m build
@@ -135,6 +158,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Generate the documentation
         env:
@@ -217,6 +241,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Fetch the gh-pages branch
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -32,9 +32,17 @@ jobs:
           - ubuntu-20.04
         python:
           - "3.11"
+        nox-session:
+          # To speed things up a bit we use the special ci_checks_max session
+          # that uses the same venv to run multiple linting sessions
+          - "ci_checks_max"
+          - "pytest_min"
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Print environment (debug)
+        run: env
+
       - name: Fetch sources
         uses: actions/checkout@v3
         with:
@@ -50,11 +58,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev-noxfile]
+          pip freeze
+
+      - name: Create nox venv
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox --install-only -e "$NOX_SESSION"
+
+      - name: Print pip freeze for nox venv (debug)
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: |
+          . ".nox/$NOX_SESSION/bin/activate"
+          pip freeze
+          deactivate
 
       - name: Run nox
-        # To speed things up a bit we use the special ci_checks_max session
-        # that uses the same venv to run multiple linting sessions
-        run: nox -e ci_checks_max pytest_min
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox -R -e "$NOX_SESSION"
         timeout-minutes: 10
 
   build:
@@ -76,6 +98,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U build
+          pip freeze
 
       - name: Build the source and binary distribution
         run: python -m build
@@ -110,6 +133,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Generate the documentation
         env:
@@ -192,6 +216,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Fetch the gh-pages branch
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -55,9 +55,17 @@ jobs:
           - ubuntu-20.04
         python:
           - "3.11"
+        nox-session:
+          # To speed things up a bit we use the special ci_checks_max session
+          # that uses the same venv to run multiple linting sessions
+          - "ci_checks_max"
+          - "pytest_min"
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Print environment (debug)
+        run: env
+
       - name: Fetch sources
         uses: actions/checkout@v3
         with:
@@ -73,11 +81,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev-noxfile]
+          pip freeze
+
+      - name: Create nox venv
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox --install-only -e "$NOX_SESSION"
+
+      - name: Print pip freeze for nox venv (debug)
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: |
+          . ".nox/$NOX_SESSION/bin/activate"
+          pip freeze
+          deactivate
 
       - name: Run nox
-        # To speed things up a bit we use the special ci_checks_max session
-        # that uses the same venv to run multiple linting sessions
-        run: nox -e ci_checks_max pytest_min
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox -R -e "$NOX_SESSION"
         timeout-minutes: 10
 
   build:
@@ -99,6 +121,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U build
+          pip freeze
 
       - name: Build the source and binary distribution
         run: python -m build
@@ -133,6 +156,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Generate the documentation
         env:
@@ -215,6 +239,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Fetch the gh-pages branch
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -32,9 +32,17 @@ jobs:
           - ubuntu-20.04
         python:
           - "3.11"
+        nox-session:
+          # To speed things up a bit we use the special ci_checks_max session
+          # that uses the same venv to run multiple linting sessions
+          - "ci_checks_max"
+          - "pytest_min"
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Print environment (debug)
+        run: env
+
       - name: Fetch sources
         uses: actions/checkout@v3
         with:
@@ -50,11 +58,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev-noxfile]
+          pip freeze
+
+      - name: Create nox venv
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox --install-only -e "$NOX_SESSION"
+
+      - name: Print pip freeze for nox venv (debug)
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: |
+          . ".nox/$NOX_SESSION/bin/activate"
+          pip freeze
+          deactivate
 
       - name: Run nox
-        # To speed things up a bit we use the special ci_checks_max session
-        # that uses the same venv to run multiple linting sessions
-        run: nox -e ci_checks_max pytest_min
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox -R -e "$NOX_SESSION"
         timeout-minutes: 10
 
   build:
@@ -76,6 +98,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U build
+          pip freeze
 
       - name: Build the source and binary distribution
         run: python -m build
@@ -110,6 +133,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Generate the documentation
         env:
@@ -192,6 +216,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Fetch the gh-pages branch
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -32,9 +32,17 @@ jobs:
           - ubuntu-20.04
         python:
           - "3.11"
+        nox-session:
+          # To speed things up a bit we use the special ci_checks_max session
+          # that uses the same venv to run multiple linting sessions
+          - "ci_checks_max"
+          - "pytest_min"
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Print environment (debug)
+        run: env
+
       - name: Fetch sources
         uses: actions/checkout@v3
         with:
@@ -50,11 +58,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev-noxfile]
+          pip freeze
+
+      - name: Create nox venv
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox --install-only -e "$NOX_SESSION"
+
+      - name: Print pip freeze for nox venv (debug)
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: |
+          . ".nox/$NOX_SESSION/bin/activate"
+          pip freeze
+          deactivate
 
       - name: Run nox
-        # To speed things up a bit we use the special ci_checks_max session
-        # that uses the same venv to run multiple linting sessions
-        run: nox -e ci_checks_max pytest_min
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox -R -e "$NOX_SESSION"
         timeout-minutes: 10
 
   build:
@@ -76,6 +98,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U build
+          pip freeze
 
       - name: Build the source and binary distribution
         run: python -m build
@@ -110,6 +133,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Generate the documentation
         env:
@@ -192,6 +216,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Fetch the gh-pages branch
         if: steps.mike-metadata.outputs.version

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -32,9 +32,17 @@ jobs:
           - ubuntu-20.04
         python:
           - "3.11"
+        nox-session:
+          # To speed things up a bit we use the special ci_checks_max session
+          # that uses the same venv to run multiple linting sessions
+          - "ci_checks_max"
+          - "pytest_min"
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Print environment (debug)
+        run: env
+
       - name: Fetch sources
         uses: actions/checkout@v3
         with:
@@ -50,11 +58,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev-noxfile]
+          pip freeze
+
+      - name: Create nox venv
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox --install-only -e "$NOX_SESSION"
+
+      - name: Print pip freeze for nox venv (debug)
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: |
+          . ".nox/$NOX_SESSION/bin/activate"
+          pip freeze
+          deactivate
 
       - name: Run nox
-        # To speed things up a bit we use the special ci_checks_max session
-        # that uses the same venv to run multiple linting sessions
-        run: nox -e ci_checks_max pytest_min
+        env:
+          NOX_SESSION: ${{ matrix.nox-session }}
+        run: nox -R -e "$NOX_SESSION"
         timeout-minutes: 10
 
   build:
@@ -76,6 +98,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U build
+          pip freeze
 
       - name: Build the source and binary distribution
         run: python -m build
@@ -110,6 +133,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Generate the documentation
         env:
@@ -192,6 +216,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
+          pip freeze
 
       - name: Fetch the gh-pages branch
         if: steps.mike-metadata.outputs.version


### PR DESCRIPTION
When debugging different behaviour between the GitHub workflow run and a local run it is very useful to know exactly which dependency versions are installed.

To do this we also add the `nox` session as a matrix dimention for the `nox` job, so it is easier to print the generated `nox` venv for the different sessions. This has the nice effect that nox max and min tests will run in parallel.
