### PR TITLE
Bug fixes for v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ directory will be created with the generated project name. For example:
 cd ~/devel
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
     --directory=cookiecutter \
-    --checkout v0.5.2
+    --checkout v0.6.2
 ```
 
 This command will prompt you for the project type, name, and other

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,29 +1,9 @@
 # Frequenz Repository Configuration Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-### Cookiecutter template
-
-<!-- Here upgrade steps for cookiecutter specifically -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-### Cookiecutter template
-
-<!-- Here new features for cookiecutter specifically -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Update the version used in the documentation.
 
 ### Cookiecutter template
 
-<!-- Here bug fixes for cookiecutter specifically -->
+- Update the generated version in dependencies.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,3 +8,6 @@
 
 - Update the generated version in dependencies.
 - Exclude `benchmarks/` directory from source distribution.
+- Use the native `navigation.indexes` extension from `mkdocs-material` instead of the `section-indexes` plugin.
+
+  The plugin had some issues when failing to keep up to date.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,3 +7,4 @@
 ### Cookiecutter template
 
 - Update the generated version in dependencies.
+- Exclude `benchmarks/` directory from source distribution.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/MANIFEST.in
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/MANIFEST.in
@@ -10,6 +10,7 @@ exclude mkdocs.yml
 exclude noxfile.py
 exclude src/conftest.py
 recursive-exclude .github *
+recursive-exclude benchmarks *
 recursive-exclude docs *
 {%- if cookiecutter.type == "api" %}
 recursive-exclude pytests *

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
   features:
     - content.code.annotate
     - content.code.copy
+    - navigation.indexes
     - navigation.instant
     - navigation.tabs
     - navigation.top
@@ -119,7 +120,6 @@ plugins:
 {%- endif %}
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
-  - section-index
 
 # Preview controls
 watch:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -73,7 +73,6 @@ dev-mkdocs = [
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.0",
   "mkdocs-material == 9.1.21",
-  "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
   "frequenz-repo-config[{{cookiecutter.type}}] == 0.6.2",
 ]

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.2",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.6.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -75,7 +75,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.2",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.6.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -87,7 +87,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.5.2",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.6.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -96,7 +96,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.6.2",
 {%- if cookiecutter.type != "api" %}
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Then simply run [Cookiecutter] where you want to create the new project:
 
 ```sh
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
-    --directory=cookiecutter --checkout v0.5.2
+    --directory=cookiecutter --checkout v0.6.2
 ```
 
 This command will prompt you for the project type, name, and other
@@ -238,7 +238,7 @@ the files in your existing project by using `rsync` or similar tools:
 ```sh
 cd /tmp
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
-    --directory=cookiecutter --checkout v0.5.2
+    --directory=cookiecutter --checkout v0.6.2
 rsync -vr --exclude=.git/ new-project/ /path/to/existing/project
 cd /path/to/existing/project
 git diff
@@ -283,7 +283,7 @@ git commit -a  # commit all changes
 cd ..
 cookiecutter gh:frequenz-floss/frequenz-repo-config-python \
     --directory=cookiecutter \
-    --checkout v0.5.2 \
+    --checkout v0.6.2 \
     --overwrite-if-exists \
     --replay \
     --replay-file project-directory/.cookiecutter-replay.json

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
   features:
     - content.code.annotate
     - content.code.copy
+    - navigation.indexes
     - navigation.instant
     - navigation.tabs
     - navigation.top
@@ -112,7 +113,6 @@ plugins:
             - https://sybil.readthedocs.io/en/stable/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
-  - section-index
 
 # Preview controls
 watch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ dev-mkdocs = [
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.0",
   "mkdocs-material == 9.1.21",
-  "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
 ]
 dev-mypy = [

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -289,7 +289,7 @@ To do so there is some setup that's needed:
     # ...
     dev-pytest = [
         # ...
-        "frequenz-repo-config[extra-lint-examples] == 0.5.2",
+        "frequenz-repo-config[extra-lint-examples] == 0.6.2",
     ]
     # ...
     [[tool.mypy.overrides]]
@@ -402,7 +402,7 @@ dependencies to your project, for example:
 requires = [
   "setuptools >= 67.3.2, < 68",
   "setuptools_scm[toml] >= 7.1.0, < 8",
-  "frequenz-repo-config[api] >= 0.5.2, < 0.6.0",
+  "frequenz-repo-config[api] >= 0.6.2, < 0.7.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/MANIFEST.in
@@ -7,6 +7,7 @@ exclude mkdocs.yml
 exclude noxfile.py
 exclude src/conftest.py
 recursive-exclude .github *
+recursive-exclude benchmarks *
 recursive-exclude docs *
 recursive-exclude tests *
 recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
   features:
     - content.code.annotate
     - content.code.copy
+    - navigation.indexes
     - navigation.instant
     - navigation.tabs
     - navigation.top
@@ -114,7 +115,6 @@ plugins:
             - https://frequenz-floss.github.io/frequenz-sdk-python/v0.22/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
-  - section-index
 
 # Preview controls
 watch:

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -55,7 +55,6 @@ dev-mkdocs = [
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.0",
   "mkdocs-material == 9.1.21",
-  "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
   "frequenz-repo-config[actor] == 0.6.2",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[actor] == 0.5.2",
+  "frequenz-repo-config[actor] == 0.6.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -57,7 +57,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[actor] == 0.5.2",
+  "frequenz-repo-config[actor] == 0.6.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -66,7 +66,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[actor] == 0.5.2",
+  "frequenz-repo-config[actor] == 0.6.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -75,7 +75,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.6.2",
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",
   "async-solipsism == 0.5",

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/MANIFEST.in
@@ -8,6 +8,7 @@ exclude mkdocs.yml
 exclude noxfile.py
 exclude src/conftest.py
 recursive-exclude .github *
+recursive-exclude benchmarks *
 recursive-exclude docs *
 recursive-exclude pytests *
 recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
   features:
     - content.code.annotate
     - content.code.copy
+    - navigation.indexes
     - navigation.instant
     - navigation.tabs
     - navigation.top
@@ -114,7 +115,6 @@ plugins:
             - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
-  - section-index
 
 # Preview controls
 watch:

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -53,7 +53,6 @@ dev-mkdocs = [
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.0",
   "mkdocs-material == 9.1.21",
-  "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
   "frequenz-repo-config[api] == 0.6.2",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[api] == 0.5.2",
+  "frequenz-repo-config[api] == 0.6.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -55,7 +55,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[api] == 0.5.2",
+  "frequenz-repo-config[api] == 0.6.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -65,7 +65,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[api] == 0.5.2",
+  "frequenz-repo-config[api] == 0.6.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -74,7 +74,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.6.2",
 ]
 dev = [
   "frequenz-api-test[dev-mkdocs,dev-flake8,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/MANIFEST.in
@@ -7,6 +7,7 @@ exclude mkdocs.yml
 exclude noxfile.py
 exclude src/conftest.py
 recursive-exclude .github *
+recursive-exclude benchmarks *
 recursive-exclude docs *
 recursive-exclude tests *
 recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
   features:
     - content.code.annotate
     - content.code.copy
+    - navigation.indexes
     - navigation.instant
     - navigation.tabs
     - navigation.top
@@ -114,7 +115,6 @@ plugins:
             - https://frequenz-floss.github.io/frequenz-sdk-python/v0.22/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
-  - section-index
 
 # Preview controls
 watch:

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[app] == 0.5.2",
+  "frequenz-repo-config[app] == 0.6.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -56,7 +56,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[app] == 0.5.2",
+  "frequenz-repo-config[app] == 0.6.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -65,7 +65,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[app] == 0.5.2",
+  "frequenz-repo-config[app] == 0.6.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -74,7 +74,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.6.2",
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",
   "async-solipsism == 0.5",

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -54,7 +54,6 @@ dev-mkdocs = [
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.0",
   "mkdocs-material == 9.1.21",
-  "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
   "frequenz-repo-config[app] == 0.6.2",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/MANIFEST.in
@@ -7,6 +7,7 @@ exclude mkdocs.yml
 exclude noxfile.py
 exclude src/conftest.py
 recursive-exclude .github *
+recursive-exclude benchmarks *
 recursive-exclude docs *
 recursive-exclude tests *
 recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
   features:
     - content.code.annotate
     - content.code.copy
+    - navigation.indexes
     - navigation.instant
     - navigation.tabs
     - navigation.top
@@ -112,7 +113,6 @@ plugins:
             - https://docs.python.org/3/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
-  - section-index
 
 # Preview controls
 watch:

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[lib] == 0.5.2",
+  "frequenz-repo-config[lib] == 0.6.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -53,7 +53,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[lib] == 0.5.2",
+  "frequenz-repo-config[lib] == 0.6.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -62,7 +62,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[lib] == 0.5.2",
+  "frequenz-repo-config[lib] == 0.6.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -71,7 +71,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.6.2",
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",
   "async-solipsism == 0.5",

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -51,7 +51,6 @@ dev-mkdocs = [
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.0",
   "mkdocs-material == 9.1.21",
-  "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
   "frequenz-repo-config[lib] == 0.6.2",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/MANIFEST.in
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/MANIFEST.in
@@ -7,6 +7,7 @@ exclude mkdocs.yml
 exclude noxfile.py
 exclude src/conftest.py
 recursive-exclude .github *
+recursive-exclude benchmarks *
 recursive-exclude docs *
 recursive-exclude tests *
 recursive-include py *.pyi

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
   features:
     - content.code.annotate
     - content.code.copy
+    - navigation.indexes
     - navigation.instant
     - navigation.tabs
     - navigation.top
@@ -114,7 +115,6 @@ plugins:
             - https://frequenz-floss.github.io/frequenz-sdk-python/v0.22/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search
-  - section-index
 
 # Preview controls
 watch:

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -55,7 +55,6 @@ dev-mkdocs = [
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.0",
   "mkdocs-material == 9.1.21",
-  "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
   "frequenz-repo-config[model] == 0.6.2",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[model] == 0.5.2",
+  "frequenz-repo-config[model] == 0.6.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -57,7 +57,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[model] == 0.5.2",
+  "frequenz-repo-config[model] == 0.6.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
@@ -66,7 +66,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2023.4.22",
-  "frequenz-repo-config[model] == 0.5.2",
+  "frequenz-repo-config[model] == 0.6.2",
 ]
 dev-pylint = [
   "pylint == 2.17.5",
@@ -75,7 +75,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.6.2",
   "pytest-mock == 3.11.1",
   "pytest-asyncio == 0.21.1",
   "async-solipsism == 0.5",


### PR DESCRIPTION
This PR fixes a few issues in v0.6.1 and prepares for the release of v0.6.2.

- Update docs and template version
- Exclude benchmarks from the source distribution
- Replace `section-indexes` with `navigation.indexes`
