### PR TITLE
Move cookiecutter filters to a Jinja2 extension

### DIFF
--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -9,7 +9,7 @@
   ],
   "name": null,
   "description": null,
-  "title": "{{cookiecutter | title}}",
+  "title": "{{cookiecutter | proj_title}}",
   "keywords": "(comma separated: 'frequenz', <type> and <name> are included automatically)",
   "github_org": "frequenz-floss",
   "license": [

--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -23,14 +23,6 @@
   "github_repo_name": "{{cookiecutter | github_repo_name}}",
   "default_codeowners": "(like @some-org/some-team; defaults to a team based on the repo type)",
   "_extensions": [
-    "local_extensions.as_identifier",
-    "local_extensions.default_codeowners",
-    "local_extensions.github_repo_name",
-    "local_extensions.introduction",
-    "local_extensions.keywords",
-    "local_extensions.pypi_package_name",
-    "local_extensions.python_package",
-    "local_extensions.src_path",
-    "local_extensions.title"
+    "local_extensions.RepoConfigExtension"
   ]
 }

--- a/cookiecutter/local_extensions.py
+++ b/cookiecutter/local_extensions.py
@@ -10,231 +10,264 @@ project structure.
 import json as _json
 import pathlib as _pathlib
 
-from cookiecutter.utils import simple_filter as _simple_filter
+from jinja2 import Environment as _Environment
+from jinja2.ext import Extension as _Extension
+from jinja2.nodes import Node as _Node
+from jinja2.parser import Parser as _Parser
 
 
-def _build_identifier(repo_type: str, name: str, separator: str) -> str:
-    """Build an identifier depending on the repository type.
+class RepoConfigExtension(_Extension):
+    """Extension to add variables and filters to the cookiecutter context.
 
-    Args:
-        repo_type: The repository type.
-        name: The project name.
-        separator: The separator to use to construct the identifier.
-
-    Returns:
-        The built identifier.
+    Every method starting and ending with `_FILTER_PREFIX` and `_FILTER_SUFFIX`
+    respectively will be registered as a filter. The name of the filter will be the
+    method name without the prefix and suffix.
     """
-    if separator == ".":
-        name = name.replace("-", "_")
-    if separator == "-":
-        name = name.replace("_", "-")
-    name = name.lower()
-    middle = f"{repo_type}{separator}" if repo_type != "lib" else ""
-    return f"frequenz{separator}{middle}{name}"
 
+    _FILTER_PREFIX = "_"
+    _FILTER_SUFFIX = "_filter"
 
-def _get_from_json(key: str) -> str:
-    """Get a string from the cookiecutter.json file.
+    def __init__(self, environment: _Environment):
+        """Initialize this extension.
 
-    Args:
-        key: The key to get the string for.
+        Args:
+            environment: The Jinja2 environment.
+        """
+        super().__init__(environment)
+        self._register_filters()
 
-    Returns:
-        The string from the cookiecutter.json file.
-    """
-    with open("../cookiecutter.json", encoding="utf8") as cookiecutter_json_file:
-        return str(_json.load(cookiecutter_json_file)[key])
+    def parse(self, parser: _Parser) -> _Node | list[_Node]:
+        """Parse tags declared by this extension.
 
+        This is a NOP because we don't declare any tags, but we need to implement this
+        methods because it's abstract in the base class.
 
-# Ignoring because cookiecutter simple_filter decorator is not typed.
-@_simple_filter  # type: ignore[misc]
-def as_identifier(name: str) -> str:
-    """Convert a name to a valid identifier.
+        Args:
+            parser: The Jinja2 parser.
 
-    Args:
-        name: The name to convert.
+        Returns:
+            An empty list.
+        """
+        return []
 
-    Returns:
-        The converted identifier.
-    """
-    return name.lower().replace("-", "_")
+    def _register_filters(self) -> None:
+        """Register all filters in this extension with the Jinja2 environment."""
+        filters = [
+            name[len(self._FILTER_PREFIX) : -len(self._FILTER_SUFFIX)]
+            for name in dir(self)
+            if name.startswith(self._FILTER_PREFIX)
+            and name.endswith(self._FILTER_SUFFIX)
+        ]
+        for filer_name in filters:
+            attr_name = f"{self._FILTER_PREFIX}{filer_name}{self._FILTER_SUFFIX}"
+            self.environment.filters[filer_name] = getattr(self, attr_name)
 
+    def _build_identifier(self, repo_type: str, name: str, separator: str) -> str:
+        """Build an identifier depending on the repository type.
 
-@_simple_filter  # type: ignore[misc]
-def python_package(cookiecutter: dict[str, str]) -> str:
-    """Generate the Python package (import) depending on the repository type.
+        Args:
+            repo_type: The repository type.
+            name: The project name.
+            separator: The separator to use to construct the identifier.
 
-    Args:
-        cookiecutter: The cookiecutter context.
+        Returns:
+            The built identifier.
+        """
+        if separator == ".":
+            name = name.replace("-", "_")
+        if separator == "-":
+            name = name.replace("_", "-")
+        name = name.lower()
+        middle = f"{repo_type}{separator}" if repo_type != "lib" else ""
+        return f"frequenz{separator}{middle}{name}"
 
-    Returns:
-        The Python package name that can be used in import statements.
-    """
-    return _build_identifier(cookiecutter["type"], cookiecutter["name"], ".")
+    def _get_from_json(self, key: str) -> str:
+        """Get a string from the cookiecutter.json file.
 
+        Args:
+            key: The key to get the string for.
 
-@_simple_filter  # type: ignore[misc]
-def pypi_package_name(cookiecutter: dict[str, str]) -> str:
-    """Generate the PyPI package name depending on the repository type.
+        Returns:
+            The string from the cookiecutter.json file.
+        """
+        with open("../cookiecutter.json", encoding="utf8") as cookiecutter_json_file:
+            return str(_json.load(cookiecutter_json_file)[key])
 
-    Args:
-        cookiecutter: The cookiecutter context.
+    def _as_identifier_filter(self, name: str) -> str:
+        """Convert a name to a valid identifier.
 
-    Returns:
-        The PyPI package name depending on the repository type.
-    """
-    return _build_identifier(cookiecutter["type"], cookiecutter["name"], "-")
+        Args:
+            name: The name to convert.
 
+        Returns:
+            The converted identifier.
+        """
+        return name.lower().replace("-", "_")
 
-@_simple_filter  # type: ignore[misc]
-def github_repo_name(cookiecutter: dict[str, str]) -> str:
-    """Generate the Python package name depending on the repository type.
+    def _python_package_filter(self, cookiecutter: dict[str, str]) -> str:
+        """Generate the Python package (import) depending on the repository type.
 
-    Args:
-        cookiecutter: The cookiecutter context.
+        Args:
+            cookiecutter: The cookiecutter context.
 
-    Returns:
-        The Python package name depending on the repository type.
-    """
-    pypi = _build_identifier(cookiecutter["type"], cookiecutter["name"], "-")
-    end = "-python" if cookiecutter["type"] == "lib" else ""
-    return f"{pypi}{end}"
+        Returns:
+            The Python package name that can be used in import statements.
+        """
+        return self._build_identifier(cookiecutter["type"], cookiecutter["name"], ".")
 
+    def _pypi_package_name_filter(self, cookiecutter: dict[str, str]) -> str:
+        """Generate the PyPI package name depending on the repository type.
 
-@_simple_filter  # type: ignore[misc]
-def title(cookiecutter: dict[str, str]) -> str:
-    """Build a default mkdocs site name for the project.
+        Args:
+            cookiecutter: The cookiecutter context.
 
-    Args:
-        cookiecutter: The cookiecutter context.
+        Returns:
+            The PyPI package name depending on the repository type.
+        """
+        return self._build_identifier(cookiecutter["type"], cookiecutter["name"], "-")
 
-    Returns:
-        The default site name.
-    """
-    name = cookiecutter["name"].replace("_", " ").replace("-", " ").title()
-    match cookiecutter["type"]:
-        case "actor":
-            return f"Frequenz {name} Actor"
-        case "api":
-            return f"Frequenz {name} API"
-        case "lib":
-            return f"Freqenz {name} Library"
-        case "app":
-            return f"Frequenz {name} Application"
-        case "model":
-            return f"Frequenz {name} AI Model"
-        case _ as repo_type:
-            assert False, f"Unhandled repository type {repo_type!r}"
+    def _github_repo_name_filter(self, cookiecutter: dict[str, str]) -> str:
+        """Generate the Python package name depending on the repository type.
 
+        Args:
+            cookiecutter: The cookiecutter context.
 
-@_simple_filter  # type: ignore[misc]
-def src_path(cookiecutter: dict[str, str]) -> str:
-    """Build a default source path for the project.
+        Returns:
+            The Python package name depending on the repository type.
+        """
+        pypi = self._build_identifier(cookiecutter["type"], cookiecutter["name"], "-")
+        end = "-python" if cookiecutter["type"] == "lib" else ""
+        return f"{pypi}{end}"
 
-    Args:
-        cookiecutter: The cookiecutter context.
+    def _title_filter(self, cookiecutter: dict[str, str]) -> str:
+        """Build a default mkdocs site name for the project.
 
-    Returns:
-        The default source path.
-    """
-    match cookiecutter["type"]:
-        case "api":
-            return "py"
-        case "actor" | "lib" | "app" | "model":
-            return "src"
-        case _ as repo_type:
-            assert False, f"Unhandled repository type {repo_type!r}"
+        Args:
+            cookiecutter: The cookiecutter context.
 
+        Returns:
+            The default site name.
+        """
+        name = cookiecutter["name"].replace("_", " ").replace("-", " ").title()
+        match cookiecutter["type"]:
+            case "actor":
+                return f"Frequenz {name} Actor"
+            case "api":
+                return f"Frequenz {name} API"
+            case "lib":
+                return f"Freqenz {name} Library"
+            case "app":
+                return f"Frequenz {name} Application"
+            case "model":
+                return f"Frequenz {name} AI Model"
+            case _ as repo_type:
+                assert False, f"Unhandled repository type {repo_type!r}"
 
-@_simple_filter  # type: ignore[misc]
-def keywords(cookiecutter: dict[str, str]) -> str:
-    """Extend cookiecutter["keywords"] with predefined ones by repository type.
+    def _src_path_filter(self, cookiecutter: dict[str, str]) -> str:
+        """Build a default source path for the project.
 
-    Args:
-        cookiecutter: The cookiecutter context.
+        Args:
+            cookiecutter: The cookiecutter context.
 
-    Returns:
-        The extended keywords.
-    """
-    repo_type = cookiecutter["type"]
-    extended_keywords = ["frequenz", "python", repo_type]
-    match repo_type:
-        case "api":
-            extended_keywords.extend(["grpc", "protobuf", "rpc"])
-        case "app":
-            extended_keywords.extend(["application"])
-        case "lib":
-            extended_keywords.extend(["library"])
-        case "model":
-            extended_keywords.extend(["ai", "ml", "machine-learning"])
-    extended_keywords.append(cookiecutter["name"])
-    default = _get_from_json("keywords")
-    cookiecutter_keywords = cookiecutter["keywords"]
-    if cookiecutter_keywords == default:
-        cookiecutter_keywords = ""
-    extended_keywords.extend(k.strip() for k in cookiecutter_keywords.split(",") if k)
-    return _json.dumps(extended_keywords)
+        Returns:
+            The default source path.
+        """
+        match cookiecutter["type"]:
+            case "api":
+                return "py"
+            case "actor" | "lib" | "app" | "model":
+                return "src"
+            case _ as repo_type:
+                assert False, f"Unhandled repository type {repo_type!r}"
 
+    def _keywords_filter(self, cookiecutter: dict[str, str]) -> str:
+        """Extend cookiecutter["keywords"] with predefined ones by repository type.
 
-@_simple_filter  # type: ignore[misc]
-def default_codeowners(cookiecutter: dict[str, str]) -> str:
-    """Build a default description for the project.
+        Args:
+            cookiecutter: The cookiecutter context.
 
-    Args:
-        cookiecutter: The cookiecutter context.
+        Returns:
+            The extended keywords.
+        """
+        repo_type = cookiecutter["type"]
+        extended_keywords = ["frequenz", "python", repo_type]
+        match repo_type:
+            case "api":
+                extended_keywords.extend(["grpc", "protobuf", "rpc"])
+            case "app":
+                extended_keywords.extend(["application"])
+            case "lib":
+                extended_keywords.extend(["library"])
+            case "model":
+                extended_keywords.extend(["ai", "ml", "machine-learning"])
+        extended_keywords.append(cookiecutter["name"])
+        default = self._get_from_json("keywords")
+        cookiecutter_keywords = cookiecutter["keywords"]
+        if cookiecutter_keywords == default:
+            cookiecutter_keywords = ""
+        extended_keywords.extend(
+            k.strip() for k in cookiecutter_keywords.split(",") if k
+        )
+        return _json.dumps(extended_keywords)
 
-    Returns:
-        The default description.
-    """
-    repo_type = cookiecutter["type"]
+    def _default_codeowners_filter(self, cookiecutter: dict[str, str]) -> str:
+        """Build a default description for the project.
 
-    codeowners = cookiecutter["default_codeowners"]
-    default = _get_from_json("default_codeowners")
-    if codeowners != default:
-        return codeowners
+        Args:
+            cookiecutter: The cookiecutter context.
 
-    github_org = _get_from_json("github_org")
-    if github_org != "frequenz-floss":
-        return f"TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)"
+        Returns:
+            The default description.
+        """
+        repo_type = cookiecutter["type"]
 
-    type_to_team = {
-        "actor": "TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)"
-        "# Temporary, should probably change",
-        "api": "@frequenz-floss/api-team",
-        "lib": "@frequenz-floss/python-sdk-team",
-        "app": "@frequenz-floss/python-sdk-team @frequenz-floss/datasci-team "
-        "# Temporary, should probably change",
-        "model": "@frequenz-floss/datasci-team",
-    }
+        codeowners = cookiecutter["default_codeowners"]
+        default = self._get_from_json("default_codeowners")
+        if codeowners != default:
+            return codeowners
 
-    assert repo_type in type_to_team, f"Unhandled repository type {repo_type!r}"
+        github_org = self._get_from_json("github_org")
+        if github_org != "frequenz-floss":
+            return f"TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)"
 
-    return type_to_team[repo_type]
+        type_to_team = {
+            "actor": "TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)"
+            "# Temporary, should probably change",
+            "api": "@frequenz-floss/api-team",
+            "lib": "@frequenz-floss/python-sdk-team",
+            "app": "@frequenz-floss/python-sdk-team @frequenz-floss/datasci-team "
+            "# Temporary, should probably change",
+            "model": "@frequenz-floss/datasci-team",
+        }
 
+        assert repo_type in type_to_team, f"Unhandled repository type {repo_type!r}"
 
-@_simple_filter  # type: ignore[misc]
-def introduction(
-    cookiecutter: dict[str, str]  # pylint: disable=unused-argument
-) -> str:
-    """Build an introduction text for the project generation.
+        return type_to_team[repo_type]
 
-    Args:
-        cookiecutter: The cookiecutter context.
+    def _introduction_filter(
+        self, cookiecutter: dict[str, str]  # pylint: disable=unused-argument
+    ) -> str:
+        """Build an introduction text for the project generation.
 
-    Returns:
-        The introduction text.
-    """
-    with (_pathlib.Path(__file__).parent / "variable-reference.md").open() as doc_file:
-        variable_reference = doc_file.read()
-    return f"""]
+        Args:
+            cookiecutter: The cookiecutter context.
 
-Welcome to repo-config Cookiecutter template!
+        Returns:
+            The introduction text.
+        """
+        with (
+            _pathlib.Path(__file__).parent / "variable-reference.md"
+        ).open() as doc_file:
+            variable_reference = doc_file.read()
+        return f"""]
 
-This template will help you to create a new repository for your project. \
-You will be asked to provide some information about your project.
+    Welcome to repo-config Cookiecutter template!
 
-Here is an explanation of what each variable is for and will be used for:
+    This template will help you to create a new repository for your project. \
+    You will be asked to provide some information about your project.
 
-{variable_reference}
+    Here is an explanation of what each variable is for and will be used for:
 
-[Please press any key to continue"""
+    {variable_reference}
+
+    [Please press any key to continue"""

--- a/cookiecutter/local_extensions.py
+++ b/cookiecutter/local_extensions.py
@@ -59,6 +59,8 @@ class RepoConfigExtension(_Extension):
             and name.endswith(self._FILTER_SUFFIX)
         ]
         for filer_name in filters:
+            if filer_name in self.environment.filters:
+                raise ValueError(f"Filter {filer_name!r} already registered")
             attr_name = f"{self._FILTER_PREFIX}{filer_name}{self._FILTER_SUFFIX}"
             self.environment.filters[filer_name] = getattr(self, attr_name)
 
@@ -139,7 +141,7 @@ class RepoConfigExtension(_Extension):
         end = "-python" if cookiecutter["type"] == "lib" else ""
         return f"{pypi}{end}"
 
-    def _title_filter(self, cookiecutter: dict[str, str]) -> str:
+    def _proj_title_filter(self, cookiecutter: dict[str, str]) -> str:
         """Build a default mkdocs site name for the project.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dev-pytest = [
   "pytest == 7.4.2",
   "pylint == 2.17.5",      # We need this to check for the examples
   "cookiecutter == 2.1.1", # For checking the cookiecutter scripts
+  "jinja2 == 3.1.2",       # For checking the cookiecutter scripts
   "sybil == 5.0.3",        # Should be consistent with the extra-lint-examples dependency
 ]
 dev = [


### PR DESCRIPTION
Move cookiecutter filters to a Jinja2 extension
    
By using a full fledged Jinja2 extension we can not only add filters but also variables. This also simplifies the `cookiecutter.json` file, as we don't need to enumerate every single filter we want to use. This also simplifies the template update process as when new fitlers are added there is no need to update the cookiecutter replay file, also minimizing chances of weird erros when that happens.
    
Also make sure we don't override existing filters, so we need to rename `title` as it was overriding the `title` built-in filter.
