### PR TITLE
Make dependabot update monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -34,6 +35,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      time: "07:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -35,7 +34,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "06:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@
 - CI
 
   - You can now make your branch protection rule only require the "Test with nox" CI job to pass. All the matrix expansions will merge into it, so there is no need to change branch protection rules if matrix elements are added or removed.
+  - Dependabot now will check for updates monthly and on a random day and time.
 
 ## New Features
 
@@ -43,6 +44,7 @@
   - Add CI job to test package installation on multiple platforms (amd64 and arm64).
   - Add CI job to run the tests in arm64.
   - Add a CI job to *join* all `nox` runs, so only one branch protection rule needs to be used.
+  - Dependabot now will check for updates monthly and on a random day and time. This is to avoid all repositories updating at the same time.
 
 ## Bug Fixes
 

--- a/cookiecutter/local_extensions.py
+++ b/cookiecutter/local_extensions.py
@@ -8,7 +8,9 @@ project structure.
 """
 
 import json as _json
+import os as _os
 import pathlib as _pathlib
+import random as _random
 
 from jinja2 import Environment as _Environment
 from jinja2.ext import Extension as _Extension
@@ -35,6 +37,11 @@ class RepoConfigExtension(_Extension):
         """
         super().__init__(environment)
         self._register_filters()
+        self.environment.globals.update(
+            {
+                "random_weekday": self._get_random_weekday(),
+            }
+        )
 
     def parse(self, parser: _Parser) -> _Node | list[_Node]:
         """Parse tags declared by this extension.
@@ -94,6 +101,27 @@ class RepoConfigExtension(_Extension):
         """
         with open("../cookiecutter.json", encoding="utf8") as cookiecutter_json_file:
             return str(_json.load(cookiecutter_json_file)[key])
+
+    def _get_random_weekday(self) -> str:
+        """Get a random weekday.
+
+        Returns:
+            A random weekday.
+        """
+        # Make sure tests are reproduceable
+        if _os.environ.get("PYTEST_CURRENT_TEST") is not None:
+            return "monday"
+        return _random.choice(
+            [
+                "monday",
+                "tuesday",
+                "wednesday",
+                "thursday",
+                "friday",
+                "saturday",
+                "sunday",
+            ]
+        )
 
     def _as_identifier_filter(self, name: str) -> str:
         """Convert a name to a valid identifier.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
     labels:
       - "part:tooling"
@@ -53,7 +53,7 @@ updates:
     ignore:
       - dependency-name: "submodules/frequenz-api-common"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "07:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -35,7 +34,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "06:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -54,7 +52,6 @@ updates:
       - dependency-name: "submodules/frequenz-api-common"
     schedule:
       interval: "monthly"
-      time: "06:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "{{ random_weekday }}"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -34,6 +35,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "{{ random_weekday }}"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -52,6 +54,7 @@ updates:
       - dependency-name: "submodules/frequenz-api-common"
     schedule:
       interval: "monthly"
+      day: "{{ random_weekday }}"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "07:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -35,7 +34,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "06:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -34,6 +35,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
     labels:
       - "part:tooling"
@@ -52,7 +52,7 @@ updates:
     ignore:
       - dependency-name: "submodules/frequenz-api-common"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "07:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -35,7 +34,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "06:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -53,7 +51,6 @@ updates:
       - dependency-name: "submodules/frequenz-api-common"
     schedule:
       interval: "monthly"
-      time: "06:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -34,6 +35,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -51,6 +53,7 @@ updates:
       - dependency-name: "submodules/frequenz-api-common"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "07:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -35,7 +34,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "06:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -34,6 +35,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "07:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -35,7 +34,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "06:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -34,6 +35,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "07:00"
     labels:
       - "part:tooling"
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
     labels:
       - "part:tooling"

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "07:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -35,7 +34,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      time: "06:00"
     labels:
       - "part:tooling"
       - "type:tech-debt"

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"
@@ -34,6 +35,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"


### PR DESCRIPTION
- Update dependabot configuration to run monthly
- Remove `time` from Dependabot config
- Use a random day of the week for Dependabot updates
- Update release notes
