### PR TITLE
Add a navigation footer to show previous and next pages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,7 @@
   - New [`mkdocs-macros`](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) extension.
   - Show inherited attributes in the documentation.
   - Make code annotations numbered. This is useful to hint about the order one should read the annotations.
+  - Add a navigation footer to show previous and next pages. This is specially useful when reading the documentation in a mobile device since the navigation bar is hidden.
   - Updated dependencies.
 
 - CI

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
     - content.code.copy
     - navigation.indexes
     - navigation.instant
+    - navigation.footer
     - navigation.tabs
     - navigation.top
     - navigation.tracking

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ theme:
     - content.code.copy
     - navigation.indexes
     - navigation.instant
+    - navigation.footer
     - navigation.tabs
     - navigation.top
     - navigation.tracking

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
     - content.code.copy
     - navigation.indexes
     - navigation.instant
+    - navigation.footer
     - navigation.tabs
     - navigation.top
     - navigation.tracking

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
     - content.code.copy
     - navigation.indexes
     - navigation.instant
+    - navigation.footer
     - navigation.tabs
     - navigation.top
     - navigation.tracking

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
     - content.code.copy
     - navigation.indexes
     - navigation.instant
+    - navigation.footer
     - navigation.tabs
     - navigation.top
     - navigation.tracking

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
     - content.code.copy
     - navigation.indexes
     - navigation.instant
+    - navigation.footer
     - navigation.tabs
     - navigation.top
     - navigation.tracking

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
     - content.code.copy
     - navigation.indexes
     - navigation.instant
+    - navigation.footer
     - navigation.tabs
     - navigation.top
     - navigation.tracking


### PR DESCRIPTION
This is specially useful when reading the documentation in a mobile device since the navigation bar is hidden.
