### PR TITLE
Don't test the push event for dependabot branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
       # We only want to test the merge commit (`merge_group` event), the hashes
       # in the push were already tested by the PR checks
       - 'gh-readonly-queue/**'
+      - 'dependabot/**'
   workflow_dispatch:
 
 env:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,3 +58,5 @@
   - Fixed mermaid diagrams not rendering in the documentation.
   - `mypy` ignores for `cookiecutter` have been removed. They should have never be there as generated projects don't use `cookiecutter`.
   - `mypy` overrides now are applied to API projects too.
+
+- Dependabot branches are now not tested for `push` events, as they are already tested by `pull` events.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ on:
       # We only want to test the merge commit (`merge_group` event), the hashes
       # in the push were already tested by the PR checks
       - 'gh-readonly-queue/**'
+      - 'dependabot/**'
   workflow_dispatch:
 
 env:

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
       # We only want to test the merge commit (`merge_group` event), the hashes
       # in the push were already tested by the PR checks
       - 'gh-readonly-queue/**'
+      - 'dependabot/**'
   workflow_dispatch:
 
 env:

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
       # We only want to test the merge commit (`merge_group` event), the hashes
       # in the push were already tested by the PR checks
       - 'gh-readonly-queue/**'
+      - 'dependabot/**'
   workflow_dispatch:
 
 env:

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
       # We only want to test the merge commit (`merge_group` event), the hashes
       # in the push were already tested by the PR checks
       - 'gh-readonly-queue/**'
+      - 'dependabot/**'
   workflow_dispatch:
 
 env:

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
       # We only want to test the merge commit (`merge_group` event), the hashes
       # in the push were already tested by the PR checks
       - 'gh-readonly-queue/**'
+      - 'dependabot/**'
   workflow_dispatch:
 
 env:

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
       # We only want to test the merge commit (`merge_group` event), the hashes
       # in the push were already tested by the PR checks
       - 'gh-readonly-queue/**'
+      - 'dependabot/**'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The push event is already tested by the PR checks, so we don't need to test it again.

Fixes #153.
