### PR TITLE
Don't run cookiecutter tests in arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,7 +177,10 @@ jobs:
             --net=host \
             --platform linux/${{ matrix.arch }} \
             localhost/nox-cross-arch:latest \
-            bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -e ${{ matrix.nox-session }}"
+            bash -c "pip install -e .[dev-noxfile]; \
+                     nox --install-only -e ${{ matrix.nox-session }}; \
+                     pip freeze; \
+                     nox -e ${{ matrix.nox-session }} -- -m 'not cookiecutter'"
         timeout-minutes: 30
 
       # This ensures that the runner has access to the pip cache.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ ignore_missing_imports = true
 testpaths = ["src", "tests"]
 markers = [
   "integration: integration tests (deselect with '-m \"not integration\"')",
+  "cookiecutter: integration tests (deselect with '-m \"not cookiecutter\"')",
 ]
 
 [tool.setuptools_scm]

--- a/tests/integration/test_cookiecutter_generation.py
+++ b/tests/integration/test_cookiecutter_generation.py
@@ -27,6 +27,7 @@ Make sure to review the changes before committing them and setting this back to 
 
 
 @pytest.mark.integration
+@pytest.mark.cookiecutter
 @pytest.mark.parametrize("repo_type", [*config.RepositoryType])
 def test_golden(
     tmp_path: pathlib.Path,
@@ -66,6 +67,7 @@ def test_golden(
 
 
 @pytest.mark.integration
+@pytest.mark.cookiecutter
 @pytest.mark.parametrize("repo_type", [*config.RepositoryType])
 def test_generation(tmp_path: pathlib.Path, repo_type: config.RepositoryType) -> None:
     """Test generation of a new repo."""


### PR DESCRIPTION
We don't really create project in arm64 yet, so it's not strictly necessary to have it tested, and test in arm64 take too long as they need to run in a emulator.
    
If at some point arm64 is popular enough so we want to make sure new projects can be started in it, there will probably be more accessible native arm64 GitHub Actions runners.

To do this we mark cookiecutter tests, so we can easily exclude them.

Fixes #152.