### PR TITLE
Add support for pylint 3.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,28 +1,29 @@
 # Frequenz Repository Configuration Release Notes
 
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
 ## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ### Cookiecutter template
 
-Instead of regenerating the templates, you can simply:
+<!-- Here upgrade steps for cookiecutter specifically -->
 
-- Run this command to fix the typo and wrong `cli` package:
+## New Features
 
-  ```sh
-  sed -i 's/annothations/annotations/' docs/_css/style.css
-  sed -i 's/frequenz\.repo\.config\.cli\.version\.mkdocs\.sort/frequenz.repo.config.cli.version.mike.sort/' .github/workflows/ci.yaml
-  ```
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
-- Replace the comment after the copyright notice in `.github/containers/nox-cross-arch/arm64-ubuntu-20.04-python-3.11.Dockerfile` with:
+### Cookiecutter template
 
-  ```Dockerfile
-  # This Dockerfile is used to run the tests in arm64, which is not supported by
-  # GitHub Actions at the moment.
-  ```
+<!-- Here new features for cookiecutter specifically -->
 
 ## Bug Fixes
 
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+
 ### Cookiecutter template
 
-- docs: Fix typo in `docs/_css/style.css` ("annothations" -> "annotations")
-- ci: Fix the description of the arm64 `Dockerfile`
+<!-- Here bug fixes for cookiecutter specifically -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,28 +2,12 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This release adds support for `pylint` 3, so downstream projects can upgrade their `pylint` version.
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+If upgrading `pylint` you might get a few new check errors.
 
 ### Cookiecutter template
 
-<!-- Here upgrade steps for cookiecutter specifically -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-### Cookiecutter template
-
-<!-- Here new features for cookiecutter specifically -->
-
-## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
-
-### Cookiecutter template
-
-<!-- Here bug fixes for cookiecutter specifically -->
+There is no need to regenerate any templates with this release.

--- a/cookiecutter/hooks/post_gen_project.py
+++ b/cookiecutter/hooks/post_gen_project.py
@@ -525,7 +525,7 @@ def finish_model_setup() -> None:
     """
 
 
-def try_run(
+def try_run(  # pylint: disable=too-many-arguments
     cmd: list[str] | str,
     /,
     *,

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -93,7 +93,7 @@ dev-noxfile = [
   "frequenz-repo-config[{{cookiecutter.type}}] == 0.7.0",
 ]
 dev-pylint = [
-  "pylint == 2.17.5",
+  "pylint == 3.0.2",
   # For checking the noxfile, docs/ script, and tests
   "{{cookiecutter.pypi_package_name}}[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 7.4.2",
-  "pylint == 2.17.5",      # We need this to check for the examples
+  "pylint == 3.0.2",       # We need this to check for the examples
   "cookiecutter == 2.1.1", # For checking the cookiecutter scripts
   "jinja2 == 3.1.2",       # For checking the cookiecutter scripts
   "sybil == 5.0.3",        # Should be consistent with the extra-lint-examples dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ app = []
 lib = []
 model = []
 extra-lint-examples = [
-  "pylint >= 2.17.3, < 3",
+  "pylint >= 2.17.3, < 4",
   "pytest >= 7.3.0, < 8",
   "sybil >= 5.0.3, < 6",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -72,7 +72,7 @@ dev-noxfile = [
   "frequenz-repo-config[actor] == 0.7.0",
 ]
 dev-pylint = [
-  "pylint == 2.17.5",
+  "pylint == 3.0.2",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-actor-test[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -71,7 +71,7 @@ dev-noxfile = [
   "frequenz-repo-config[api] == 0.7.0",
 ]
 dev-pylint = [
-  "pylint == 2.17.5",
+  "pylint == 3.0.2",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-test[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -71,7 +71,7 @@ dev-noxfile = [
   "frequenz-repo-config[app] == 0.7.0",
 ]
 dev-pylint = [
-  "pylint == 2.17.5",
+  "pylint == 3.0.2",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-app-test[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -68,7 +68,7 @@ dev-noxfile = [
   "frequenz-repo-config[lib] == 0.7.0",
 ]
 dev-pylint = [
-  "pylint == 2.17.5",
+  "pylint == 3.0.2",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-test[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -72,7 +72,7 @@ dev-noxfile = [
   "frequenz-repo-config[model] == 0.7.0",
 ]
 dev-pylint = [
-  "pylint == 2.17.5",
+  "pylint == 3.0.2",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-model-test[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]


### PR DESCRIPTION
This is needed for downstream projects to be able to upgrade to `pylint` 3.0.

- Extend the range of supported pylint versions
- Bump pylint to 3.0.2
- cookiecutter: Bump pylint dependency to 3.0.2
