### PR TITLE
docs: Hide `conftest` at any level

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,3 +11,7 @@ If upgrading `pylint` you might get a few new check errors.
 ### Cookiecutter template
 
 There is no need to regenerate any templates with this release.
+
+## Bug Fixes
+
+- `mkdocs`: The `conftest` module is now properly hidden from the documentation again.

--- a/src/frequenz/repo/config/mkdocs/api_pages.py
+++ b/src/frequenz/repo/config/mkdocs/api_pages.py
@@ -35,7 +35,7 @@ def _is_internal(path_parts: Tuple[str, ...]) -> bool:
     def with_underscore_not_init(part: str) -> bool:
         return part.startswith("_") and part != "__init__"
 
-    is_conftest = len(path_parts) == 1 and path_parts[0] == "conftest"
+    is_conftest = path_parts[-1] == "conftest" if path_parts else False
 
     return is_conftest or any(p for p in path_parts if with_underscore_not_init(p))
 


### PR DESCRIPTION
Now that `conftest` to test examples can live at a higher level in the directory structure it is better to ignore any `conftest` module, even if there is a slim chance that anyone could have a `conftest` module that should be part of the public interface (which will conflict with `pytest` anyway).
