### PR TITLE
docs: Improve mention of `cmd:skip-release-notes` label

### DIFF
--- a/docs/user-guide/start-a-new-project/github-configuration.md
+++ b/docs/user-guide/start-a-new-project/github-configuration.md
@@ -12,11 +12,10 @@ Review the list of labels and add:
 
 * `part:xxx` labels that make sense to the project
 
-* Add a `cmd:skip-release-notes` with the following description:
+* Make sure there is a `cmd:skip-release-notes` label, and if there isn't,
+  create one with `930F79` as color and the following description:
 
     > It is not necessary to update release notes for this PR
-
-    And `930F79` as color.
 
 * All labels used by automation in the project, for example look for labels listed in:
 


### PR DESCRIPTION
The label is automatically created in the `frequenz-floss` organization, so it is not necessary to create it manually. But when used to create repos in another organization, it might be, so we need to still explaining how to create it.
