### PR TITLE
Remove `custom_templates` from `mkdocs.yml`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,3 +28,4 @@
 ### Cookiecutter template
 
 * Fix typo: `Freqenz` -> `Frequenz`
+* Fix `mkdocs.yml` to avoid specifying `custom_templates` for `mkdocstrings` as it is unused and is checked for existence in newer versions.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -100,7 +100,6 @@ plugins:
       alias_type: redirect
       canonical_version: latest
   - mkdocstrings:
-      custom_templates: templates
       default_handler: python
       handlers:
         python:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,7 +98,6 @@ plugins:
       alias_type: redirect
       canonical_version: latest
   - mkdocstrings:
-      custom_templates: templates
       default_handler: python
       handlers:
         python:

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
@@ -100,7 +100,6 @@ plugins:
       alias_type: redirect
       canonical_version: latest
   - mkdocstrings:
-      custom_templates: templates
       default_handler: python
       handlers:
         python:

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
@@ -100,7 +100,6 @@ plugins:
       alias_type: redirect
       canonical_version: latest
   - mkdocstrings:
-      custom_templates: templates
       default_handler: python
       handlers:
         python:

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
@@ -100,7 +100,6 @@ plugins:
       alias_type: redirect
       canonical_version: latest
   - mkdocstrings:
-      custom_templates: templates
       default_handler: python
       handlers:
         python:

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
@@ -100,7 +100,6 @@ plugins:
       alias_type: redirect
       canonical_version: latest
   - mkdocstrings:
-      custom_templates: templates
       default_handler: python
       handlers:
         python:

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
@@ -100,7 +100,6 @@ plugins:
       alias_type: redirect
       canonical_version: latest
   - mkdocstrings:
-      custom_templates: templates
       default_handler: python
       handlers:
         python:


### PR DESCRIPTION
It is not used and it is checked for existence in newer versions of `mkdocstrings`, making builds fail.

Fixes #184.
