### PR TITLE
Add a few more checks to the `pylint` ignore list

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,13 @@
 
 ### Cookiecutter template
 
-<!-- Here upgrade steps for cookiecutter specifically -->
+To upgrade without regenerating the project, you can follow these steps:
+
+- Run the following command to add the new `pylint` ignore rules:
+
+    ```sh
+    sed '/  # Checked by flake8/a\  "redefined-outer-name",\n  "unused-import",' pyproject.toml
+    ```
 
 ## New Features
 
@@ -18,7 +24,7 @@
 
 ### Cookiecutter template
 
-<!-- Here new features for cookiecutter specifically -->
+- Some checks that are already performed by `flake8` are now disabled in `pylint` to avoid double reporting.
 
 ## Bug Fixes
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -165,8 +165,10 @@ disable = [
   "unsubscriptable-object",
   # Checked by flake8
   "line-too-long",
-  "unused-variable",
+  "redefined-outer-name",
   "unnecessary-lambda-assignment",
+  "unused-import",
+  "unused-variable",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,8 +163,10 @@ disable = [
   "unsubscriptable-object",
   # Checked by flake8
   "line-too-long",
-  "unused-variable",
+  "redefined-outer-name",
   "unnecessary-lambda-assignment",
+  "unused-import",
+  "unused-variable",
 ]
 
 [tool.mypy]

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -139,8 +139,10 @@ disable = [
   "unsubscriptable-object",
   # Checked by flake8
   "line-too-long",
-  "unused-variable",
+  "redefined-outer-name",
   "unnecessary-lambda-assignment",
+  "unused-import",
+  "unused-variable",
 ]
 
 [tool.pytest.ini_options]

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -134,8 +134,10 @@ disable = [
   "unsubscriptable-object",
   # Checked by flake8
   "line-too-long",
-  "unused-variable",
+  "redefined-outer-name",
   "unnecessary-lambda-assignment",
+  "unused-import",
+  "unused-variable",
 ]
 
 [tool.pytest.ini_options]

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -138,8 +138,10 @@ disable = [
   "unsubscriptable-object",
   # Checked by flake8
   "line-too-long",
-  "unused-variable",
+  "redefined-outer-name",
   "unnecessary-lambda-assignment",
+  "unused-import",
+  "unused-variable",
 ]
 
 [tool.pytest.ini_options]

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -135,8 +135,10 @@ disable = [
   "unsubscriptable-object",
   # Checked by flake8
   "line-too-long",
-  "unused-variable",
+  "redefined-outer-name",
   "unnecessary-lambda-assignment",
+  "unused-import",
+  "unused-variable",
 ]
 
 [tool.pytest.ini_options]

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -139,8 +139,10 @@ disable = [
   "unsubscriptable-object",
   # Checked by flake8
   "line-too-long",
-  "unused-variable",
+  "redefined-outer-name",
   "unnecessary-lambda-assignment",
+  "unused-import",
+  "unused-variable",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This is to avoid double reporting of some checks that are already performed by `flake8`.

Also sort the list alphabetically so it is easier to find a specific check.