### PR TITLE
ci: Support using git for dependencies in `test-installation`

### DIFF
--- a/.github/containers/test-installation/Dockerfile
+++ b/.github/containers/test-installation/Dockerfile
@@ -6,7 +6,12 @@
 
 FROM --platform=${TARGETPLATFORM} python:3.11-slim
 
-RUN python -m pip install --upgrade --no-cache-dir pip
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+    git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
 RUN pip install dist/*.whl && \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,6 +58,30 @@ To upgrade without regenerating the project, you can follow these steps:
 
     ```sh
     awk -i inplace '/^sed s..frequenz-api-common/ { print; print "sed '"'"'s|https://frequenz-floss.github.io/frequenz-api-common/v[0-9].[0-9]/objects.inv|https://frequenz-floss.github.io/frequenz-api-common/v'"'"'${ver_minor}'"'"'/objects.inv|'"'"' -i mkdocs.yml"; next }1' CONTRIBUTING.md
+
+- Run the following command to fix the `test-installation` CI job when using git URLs in `pyproject.toml`:
+
+    ```sh
+    patch -p1 <<'EOF'
+    diff --git a/.github/containers/test-installation/Dockerfile b/.github/containers/test-installation/Dockerfile
+    index 772b2ae..2494545 100644
+    --- a/.github/containers/test-installation/Dockerfile
+    +++ b/.github/containers/test-installation/Dockerfile
+    @@ -6,7 +6,12 @@
+
+     FROM --platform=${TARGETPLATFORM} python:3.11-slim
+
+    -RUN python -m pip install --upgrade --no-cache-dir pip
+    +RUN apt-get update -y && \
+    +    apt-get install --no-install-recommends -y \
+    +    git && \
+    +    apt-get clean && \
+    +    rm -rf /var/lib/apt/lists/* && \
+    +    python -m pip install --upgrade --no-cache-dir pip
+
+     COPY dist dist
+     RUN pip install dist/*.whl && \
+    EOF
     ```
 
 ## New Features
@@ -77,4 +101,4 @@ To upgrade without regenerating the project, you can follow these steps:
 
 ### Cookiecutter template
 
-<!-- Here bug fixes for cookiecutter specifically -->
+- Fix the `test-installation` CI job when dependencies in `pyproject.toml` contain git URLs.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/containers/test-installation/Dockerfile
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/containers/test-installation/Dockerfile
@@ -7,7 +7,12 @@
 
 FROM --platform=${TARGETPLATFORM} python:3.11-slim
 
-RUN python -m pip install --upgrade --no-cache-dir pip
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+    git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
 RUN pip install dist/*.whl && \

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/containers/test-installation/Dockerfile
@@ -5,7 +5,12 @@
 
 FROM --platform=${TARGETPLATFORM} python:3.11-slim
 
-RUN python -m pip install --upgrade --no-cache-dir pip
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+    git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
 RUN pip install dist/*.whl && \

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/containers/test-installation/Dockerfile
@@ -5,7 +5,12 @@
 
 FROM --platform=${TARGETPLATFORM} python:3.11-slim
 
-RUN python -m pip install --upgrade --no-cache-dir pip
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+    git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
 RUN pip install dist/*.whl && \

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/containers/test-installation/Dockerfile
@@ -5,7 +5,12 @@
 
 FROM --platform=${TARGETPLATFORM} python:3.11-slim
 
-RUN python -m pip install --upgrade --no-cache-dir pip
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+    git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
 RUN pip install dist/*.whl && \

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/containers/test-installation/Dockerfile
@@ -5,7 +5,12 @@
 
 FROM --platform=${TARGETPLATFORM} python:3.11-slim
 
-RUN python -m pip install --upgrade --no-cache-dir pip
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+    git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
 RUN pip install dist/*.whl && \

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/containers/test-installation/Dockerfile
@@ -5,7 +5,12 @@
 
 FROM --platform=${TARGETPLATFORM} python:3.11-slim
 
-RUN python -m pip install --upgrade --no-cache-dir pip
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+    git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
 RUN pip install dist/*.whl && \


### PR DESCRIPTION
Fix the CI test that fails when dependencies in pyproject.toml contain git urls.

I didn't have time to update the tests, feel free to take over.
