### PR TITLE
Fetch submodules when doing cross-arch tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -84,6 +84,15 @@ To upgrade without regenerating the project, you can follow these steps:
      COPY dist dist
      RUN pip install dist/*.whl && \
     EOF
+
+- If your repository uses submodules and do cross-arch tests, you need to update the `nox-cross-arch` job in the `.github/workflows/ci.yaml` workflow and add the option `submodules: true` to the `checkout` action, for example:
+
+    ```yaml
+    steps:
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
     ```
 
 ## New Features
@@ -103,4 +112,8 @@ To upgrade without regenerating the project, you can follow these steps:
 
 ### Cookiecutter template
 
+<<<<<<< HEAD
 - Fix the `test-installation` CI job when dependencies in `pyproject.toml` contain git URLs.
+=======
+- Fix cross-arch testing for respositories with submodules.
+>>>>>>> ed6cc5f (Fetch submodules when doing cross-arch tests)

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -143,6 +143,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -117,6 +117,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -140,6 +140,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -117,6 +117,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -117,6 +117,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -117,6 +117,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
We need to do that because if the project has submodules, they need to be available when running the tests in the container too.
