### PR TITLE
mkdocs: Show symbol type in the ToC

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,9 +34,12 @@
 
 ## Enhancements
 
+- The generated docs now show the symbol type in the table of contents.
+
 ### Cookiecutter template
 
 - The `Markdown` dependency was bumped so we don't need to add a `type: ignore` due to incorrect type hints.
+- The generated docs now show the symbol type in the table of contents.
 
 ## Bug Fixes
 

--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -33,5 +33,11 @@ echo
 manual_step "Please make sure that the 'Markdown' and 'types-Markdown' dependencies are at version 3.5.2 or higher in 'pyproject.toml':"
 grep 'Markdown' pyproject.toml
 
+echo "========================================================================"
+
+echo "Adding the new 'show_symbol_type_toc' option for MkDocs"
+sed -i '/^            show_source: true$/a \            show_symbol_type_toc: true' mkdocs.yml
+sed -i '/^  "mkdocstrings\[python\] == .*",$/a \  "mkdocstrings-python == 1.9.2",' pyproject.toml
+
 # Add a separation line like this one after each migration step.
 echo "========================================================================"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             show_root_members_full_path: true
             show_signature_annotations: true
             show_source: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             # TODO(cookiecutter): You might want to add other external references here

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -76,7 +76,8 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-macros-plugin == 1.0.4",
   "mkdocs-material == 9.3.1",
-  "mkdocstrings[python] == 0.23.0",
+  "mkdocstrings[python] == 0.24.3",
+  "mkdocstrings-python == 1.9.2",
   "frequenz-repo-config[{{cookiecutter.type}}] == 0.9.1",
 ]
 dev-mypy = [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ plugins:
             show_root_members_full_path: true
             show_signature_annotations: true
             show_source: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             - https://cookiecutter.readthedocs.io/en/stable/objects.inv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,8 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-macros-plugin == 1.0.4",
   "mkdocs-material == 9.3.1",
-  "mkdocstrings[python] == 0.23.0",
+  "mkdocstrings[python] == 0.24.3",
+  "mkdocstrings-python == 1.9.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             show_root_members_full_path: true
             show_signature_annotations: true
             show_source: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             # TODO(cookiecutter): You might want to add other external references here

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -58,7 +58,8 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-macros-plugin == 1.0.4",
   "mkdocs-material == 9.3.1",
-  "mkdocstrings[python] == 0.23.0",
+  "mkdocstrings[python] == 0.24.3",
+  "mkdocstrings-python == 1.9.2",
   "frequenz-repo-config[actor] == 0.9.1",
 ]
 dev-mypy = [

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             show_root_members_full_path: true
             show_signature_annotations: true
             show_source: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             # TODO(cookiecutter): You might want to add other external references here

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -56,7 +56,8 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-macros-plugin == 1.0.4",
   "mkdocs-material == 9.3.1",
-  "mkdocstrings[python] == 0.23.0",
+  "mkdocstrings[python] == 0.24.3",
+  "mkdocstrings-python == 1.9.2",
   "frequenz-repo-config[api] == 0.9.1",
 ]
 dev-mypy = [

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             show_root_members_full_path: true
             show_signature_annotations: true
             show_source: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             # TODO(cookiecutter): You might want to add other external references here

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -57,7 +57,8 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-macros-plugin == 1.0.4",
   "mkdocs-material == 9.3.1",
-  "mkdocstrings[python] == 0.23.0",
+  "mkdocstrings[python] == 0.24.3",
+  "mkdocstrings-python == 1.9.2",
   "frequenz-repo-config[app] == 0.9.1",
 ]
 dev-mypy = [

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             show_root_members_full_path: true
             show_signature_annotations: true
             show_source: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             # TODO(cookiecutter): You might want to add other external references here

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -54,7 +54,8 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-macros-plugin == 1.0.4",
   "mkdocs-material == 9.3.1",
-  "mkdocstrings[python] == 0.23.0",
+  "mkdocstrings[python] == 0.24.3",
+  "mkdocstrings-python == 1.9.2",
   "frequenz-repo-config[lib] == 0.9.1",
 ]
 dev-mypy = [

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             show_root_members_full_path: true
             show_signature_annotations: true
             show_source: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             # TODO(cookiecutter): You might want to add other external references here

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -58,7 +58,8 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-macros-plugin == 1.0.4",
   "mkdocs-material == 9.3.1",
-  "mkdocstrings[python] == 0.23.0",
+  "mkdocstrings[python] == 0.24.3",
+  "mkdocstrings-python == 1.9.2",
   "frequenz-repo-config[model] == 0.9.1",
 ]
 dev-mypy = [


### PR DESCRIPTION
Enables this option: https://mkdocstrings.github.io/python/usage/configuration/headings/#show_symbol_type_toc.
