### PR TITLE
Don't recursively scan for pyproject.toml when calculating the cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,7 +159,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,4 +48,4 @@
 
 ### Cookiecutter template
 
-<!-- Here bug fixes for cookiecutter specifically -->
+- Fixed a bug where the pip cache post action fails in the CI workflow because of permissions issues.

--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -49,5 +49,10 @@ manual_step "  4. Make sure the branch name is correct (matches the branch you w
 manual_step "  5. Go to the 'Branches' section in the sidebar."
 manual_step "  6. Remove any branch protection rules that are not needed anymore (you should probably have only one configuring the merge queue if you were using other rulesets before)."
 
+echo "========================================================================"
+
+echo "Fixing pip cache in '.github/workflows/ci.yaml'"
+sed -i "|hashFiles('**/pyproject.toml')|hashFiles('pyproject.toml')|" .github/workflows/ci.yaml
+
 # Add a separation line like this one after each migration step.
 echo "========================================================================"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -187,7 +187,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -184,7 +184,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to


### PR DESCRIPTION
We don't really need to scan for `pyproject.toml` files recursively, since we only have one in the root of the repository. This should make the cache key calculation more efficient and less error prone, as when using qemu, there are some files that are not accessible and the hash calculation fails.
