### PR TITLE
Fail the nox-cross-arch-all job if any matrix job fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,10 +203,17 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
+    # We only run if there are failures, to propagate the failure, so if this
+    # check is required, it will fail if the child matrix jobs failed.
+    # If the child matrix jobs didn't run, this job will be skipped
+    # because there will be no dependency with a failure result.
+    if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-20.04
     steps:
-      - name: Return true
-        run: "true"
+      - name: Fail because some cross-arch tests failed
+        run: |
+          echo "Error: Some cross-arch tests failed"
+          exit 1
 
   build:
     name: Build distribution packages

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,3 +49,4 @@
 ### Cookiecutter template
 
 - Fixed a bug where the pip cache post action fails in the CI workflow because of permissions issues.
+- Make the `nox-cross-arch-all` job fail if any `nox-cross-arch` matrix job fails.

--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -54,5 +54,23 @@ echo "========================================================================"
 echo "Fixing pip cache in '.github/workflows/ci.yaml'"
 sed -i "|hashFiles('**/pyproject.toml')|hashFiles('pyproject.toml')|" .github/workflows/ci.yaml
 
+echo "========================================================================"
+
+echo "Fixing nox-cross-arch-all jobs to fail on child jobs failure in '.github/workflows/ci.yaml'"
+sed -i '/^    needs: \["nox-cross-arch"\]$/,/^        run: "true"$/c\
+    needs: \["nox-cross-arch"\]\
+    # We only run if there are failures, to propagate the failure, so if this\
+    # check is required, it will fail if the child matrix jobs failed.\
+    # If the child matrix jobs didn'"'"'t run, this job will be skipped\
+    # because there will be no dependency with a failure result.\
+    if: always() && contains(needs.*.result, '"'"'failure'"'"')\
+    runs-on: ubuntu-20.04\
+    steps:\
+      - name: Fail because some cross-arch tests failed\
+        run: |\
+          echo "Error: Some cross-arch tests failed"\
+          exit 1' \
+  .github/workflows/ci.yaml
+
 # Add a separation line like this one after each migration step.
 echo "========================================================================"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -228,10 +228,17 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
+    # We only run if there are failures, to propagate the failure, so if this
+    # check is required, it will fail if the child matrix jobs failed.
+    # If the child matrix jobs didn't run, this job will be skipped
+    # because there will be no dependency with a failure result.
+    if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-20.04
     steps:
-      - name: Return true
-        run: "true"
+      - name: Fail because some cross-arch tests failed
+        run: |
+          echo "Error: Some cross-arch tests failed"
+          exit 1
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -202,10 +202,17 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
+    # We only run if there are failures, to propagate the failure, so if this
+    # check is required, it will fail if the child matrix jobs failed.
+    # If the child matrix jobs didn't run, this job will be skipped
+    # because there will be no dependency with a failure result.
+    if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-20.04
     steps:
-      - name: Return true
-        run: "true"
+      - name: Fail because some cross-arch tests failed
+        run: |
+          echo "Error: Some cross-arch tests failed"
+          exit 1
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -225,10 +225,17 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
+    # We only run if there are failures, to propagate the failure, so if this
+    # check is required, it will fail if the child matrix jobs failed.
+    # If the child matrix jobs didn't run, this job will be skipped
+    # because there will be no dependency with a failure result.
+    if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-20.04
     steps:
-      - name: Return true
-        run: "true"
+      - name: Fail because some cross-arch tests failed
+        run: |
+          echo "Error: Some cross-arch tests failed"
+          exit 1
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -202,10 +202,17 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
+    # We only run if there are failures, to propagate the failure, so if this
+    # check is required, it will fail if the child matrix jobs failed.
+    # If the child matrix jobs didn't run, this job will be skipped
+    # because there will be no dependency with a failure result.
+    if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-20.04
     steps:
-      - name: Return true
-        run: "true"
+      - name: Fail because some cross-arch tests failed
+        run: |
+          echo "Error: Some cross-arch tests failed"
+          exit 1
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -202,10 +202,17 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
+    # We only run if there are failures, to propagate the failure, so if this
+    # check is required, it will fail if the child matrix jobs failed.
+    # If the child matrix jobs didn't run, this job will be skipped
+    # because there will be no dependency with a failure result.
+    if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-20.04
     steps:
-      - name: Return true
-        run: "true"
+      - name: Fail because some cross-arch tests failed
+        run: |
+          echo "Error: Some cross-arch tests failed"
+          exit 1
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -202,10 +202,17 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
+    # We only run if there are failures, to propagate the failure, so if this
+    # check is required, it will fail if the child matrix jobs failed.
+    # If the child matrix jobs didn't run, this job will be skipped
+    # because there will be no dependency with a failure result.
+    if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-20.04
     steps:
-      - name: Return true
-        run: "true"
+      - name: Fail because some cross-arch tests failed
+        run: |
+          echo "Error: Some cross-arch tests failed"
+          exit 1
 
   build:
     name: Build distribution packages


### PR DESCRIPTION
Otherwise this job will be skipped, just like when the matrix jobs are skipped, resulting in a passed check when it should have failed.
