### PR TITLE
Fix the Queue PRs for v0.x.x.json ruleset

### DIFF
--- a/github-rulesets/Queue PRs for v0.x.x.json
+++ b/github-rulesets/Queue PRs for v0.x.x.json
@@ -14,13 +14,63 @@
   },
   "rules": [
     {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_signatures"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "Test with nox",
+            "integration_id": 15368
+          },
+          {
+            "context": "Test documentation website generation",
+            "integration_id": 15368
+          },
+          {
+            "context": "Test package installation in different architectures",
+            "integration_id": 15368
+          },
+          {
+            "context": "Cross-arch tests with nox",
+            "integration_id": 15368
+          },
+          {
+            "context": "Check release notes are updated",
+            "integration_id": 15368
+          },
+          {
+            "context": "DCO"
+          }
+        ]
+      }
+    },
+    {
+      "type": "deletion"
+    },
+    {
       "type": "merge_queue",
       "parameters": {
         "merge_method": "Merge commit",
         "max_entries_to_build": 5,
-        "min_entries_to_merge": 3,
+        "min_entries_to_merge": 1,
         "max_entries_to_merge": 5,
-        "min_entries_to_merge_wait_minutes": 1,
+        "min_entries_to_merge_wait_minutes": 5,
         "grouping_strategy_all_green": true,
         "check_response_timeout_minutes": 60
       }


### PR DESCRIPTION
The ruleset now matches the requirements of the `Protect version branches` ruleset, including all CI checks that must pass.

Without this, the queued PRs were merged even if the checks failed.

This sadly introduces some redundancy, but we can't use only one rule if we want the main rule to use wildcards, so all new version branches are protected by default.
