### PR TITLE
Fix the condition to run the `nox-cross-arch-all` job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@
 # For more details on the configuration please see:
 # https://github.com/marketplace/actions/labeler
 
-"part:doc":
+"part:docs":
   - all:
     - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,10 +88,14 @@ jobs:
     # The job name should match the name of the `nox` job.
     name: Test with nox
     needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   nox-cross-arch:
     name: Cross-arch tests with nox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,17 +203,14 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
-    # We only run if there are failures, to propagate the failure, so if this
-    # check is required, it will fail if the child matrix jobs failed.
-    # If the child matrix jobs didn't run, this job will be skipped
-    # because there will be no dependency with a failure result.
-    if: always() && contains(needs.*.result, 'failure')
+    # We skip this job only if nox-cross-arch was also skipped
+    if: always() && needs.nox-cross-arch.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
     steps:
-      - name: Fail because some cross-arch tests failed
-        run: |
-          echo "Error: Some cross-arch tests failed"
-          exit 1
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   build:
     name: Build distribution packages

--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -56,14 +56,25 @@ sed -i "|hashFiles('**/pyproject.toml')|hashFiles('pyproject.toml')|" .github/wo
 
 echo "========================================================================"
 
-echo "Fixing nox-cross-arch-all jobs to fail on child jobs failure in '.github/workflows/ci.yaml'"
-sed -i '/^    needs: \["nox-cross-arch"\]$/,/^        run: "true"$/c\
+echo "Fixing nox-(cross-arch-)all jobs to fail on child jobs failure in '.github/workflows/ci.yaml'"
+sed -i \
+  -e '/^    needs: \["nox-cross-arch"\]$/,/^        run: "true"$/c\
     needs: \["nox-cross-arch"\]\
     # We skip this job only if nox-cross-arch was also skipped\
     if: always() && needs.nox-cross-arch.result != '"'"'skipped'"'"'\
     runs-on: ubuntu-20.04\
     env:\
       DEPS_RESULT: ${{ needs.nox-cross-arch.result }}\
+    steps:\
+      - name: Check matrix job result\
+        run: test "$DEPS_RESULT" = "success"' \
+  -e '/^    needs: \["nox"\]$/,/^        run: "true"$/c\
+    needs: ["nox"]\
+    # We skip this job only if nox was also skipped\
+    if: always() && needs.nox.result != '"'"'skipped'"'"'\
+    runs-on: ubuntu-20.04\
+    env:\
+      DEPS_RESULT: ${{ needs.nox.result }}\
     steps:\
       - name: Check matrix job result\
         run: test "$DEPS_RESULT" = "success"' \

--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -59,17 +59,14 @@ echo "========================================================================"
 echo "Fixing nox-cross-arch-all jobs to fail on child jobs failure in '.github/workflows/ci.yaml'"
 sed -i '/^    needs: \["nox-cross-arch"\]$/,/^        run: "true"$/c\
     needs: \["nox-cross-arch"\]\
-    # We only run if there are failures, to propagate the failure, so if this\
-    # check is required, it will fail if the child matrix jobs failed.\
-    # If the child matrix jobs didn'"'"'t run, this job will be skipped\
-    # because there will be no dependency with a failure result.\
-    if: always() && contains(needs.*.result, '"'"'failure'"'"')\
+    # We skip this job only if nox-cross-arch was also skipped\
+    if: always() && needs.nox-cross-arch.result != '"'"'skipped'"'"'\
     runs-on: ubuntu-20.04\
+    env:\
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}\
     steps:\
-      - name: Fail because some cross-arch tests failed\
-        run: |\
-          echo "Error: Some cross-arch tests failed"\
-          exit 1' \
+      - name: Check matrix job result\
+        run: test "$DEPS_RESULT" = "success"' \
   .github/workflows/ci.yaml
 
 # Add a separation line like this one after each migration step.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -114,10 +114,14 @@ jobs:
     # The job name should match the name of the `nox` job.
     name: Test with nox
     needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   nox-cross-arch:
     name: Cross-arch tests with nox

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -228,17 +228,14 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
-    # We only run if there are failures, to propagate the failure, so if this
-    # check is required, it will fail if the child matrix jobs failed.
-    # If the child matrix jobs didn't run, this job will be skipped
-    # because there will be no dependency with a failure result.
-    if: always() && contains(needs.*.result, 'failure')
+    # We skip this job only if nox-cross-arch was also skipped
+    if: always() && needs.nox-cross-arch.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
     steps:
-      - name: Fail because some cross-arch tests failed
-        run: |
-          echo "Error: Some cross-arch tests failed"
-          exit 1
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -88,10 +88,14 @@ jobs:
     # The job name should match the name of the `nox` job.
     name: Test with nox
     needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   nox-cross-arch:
     name: Cross-arch tests with nox

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -202,17 +202,14 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
-    # We only run if there are failures, to propagate the failure, so if this
-    # check is required, it will fail if the child matrix jobs failed.
-    # If the child matrix jobs didn't run, this job will be skipped
-    # because there will be no dependency with a failure result.
-    if: always() && contains(needs.*.result, 'failure')
+    # We skip this job only if nox-cross-arch was also skipped
+    if: always() && needs.nox-cross-arch.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
     steps:
-      - name: Fail because some cross-arch tests failed
-        run: |
-          echo "Error: Some cross-arch tests failed"
-          exit 1
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -111,10 +111,14 @@ jobs:
     # The job name should match the name of the `nox` job.
     name: Test with nox
     needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   nox-cross-arch:
     name: Cross-arch tests with nox

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -225,17 +225,14 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
-    # We only run if there are failures, to propagate the failure, so if this
-    # check is required, it will fail if the child matrix jobs failed.
-    # If the child matrix jobs didn't run, this job will be skipped
-    # because there will be no dependency with a failure result.
-    if: always() && contains(needs.*.result, 'failure')
+    # We skip this job only if nox-cross-arch was also skipped
+    if: always() && needs.nox-cross-arch.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
     steps:
-      - name: Fail because some cross-arch tests failed
-        run: |
-          echo "Error: Some cross-arch tests failed"
-          exit 1
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -88,10 +88,14 @@ jobs:
     # The job name should match the name of the `nox` job.
     name: Test with nox
     needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   nox-cross-arch:
     name: Cross-arch tests with nox

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -202,17 +202,14 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
-    # We only run if there are failures, to propagate the failure, so if this
-    # check is required, it will fail if the child matrix jobs failed.
-    # If the child matrix jobs didn't run, this job will be skipped
-    # because there will be no dependency with a failure result.
-    if: always() && contains(needs.*.result, 'failure')
+    # We skip this job only if nox-cross-arch was also skipped
+    if: always() && needs.nox-cross-arch.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
     steps:
-      - name: Fail because some cross-arch tests failed
-        run: |
-          echo "Error: Some cross-arch tests failed"
-          exit 1
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -88,10 +88,14 @@ jobs:
     # The job name should match the name of the `nox` job.
     name: Test with nox
     needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   nox-cross-arch:
     name: Cross-arch tests with nox

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -202,17 +202,14 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
-    # We only run if there are failures, to propagate the failure, so if this
-    # check is required, it will fail if the child matrix jobs failed.
-    # If the child matrix jobs didn't run, this job will be skipped
-    # because there will be no dependency with a failure result.
-    if: always() && contains(needs.*.result, 'failure')
+    # We skip this job only if nox-cross-arch was also skipped
+    if: always() && needs.nox-cross-arch.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
     steps:
-      - name: Fail because some cross-arch tests failed
-        run: |
-          echo "Error: Some cross-arch tests failed"
-          exit 1
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   build:
     name: Build distribution packages

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -88,10 +88,14 @@ jobs:
     # The job name should match the name of the `nox` job.
     name: Test with nox
     needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   nox-cross-arch:
     name: Cross-arch tests with nox

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -202,17 +202,14 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
-    # We only run if there are failures, to propagate the failure, so if this
-    # check is required, it will fail if the child matrix jobs failed.
-    # If the child matrix jobs didn't run, this job will be skipped
-    # because there will be no dependency with a failure result.
-    if: always() && contains(needs.*.result, 'failure')
+    # We skip this job only if nox-cross-arch was also skipped
+    if: always() && needs.nox-cross-arch.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
     steps:
-      - name: Fail because some cross-arch tests failed
-        run: |
-          echo "Error: Some cross-arch tests failed"
-          exit 1
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   build:
     name: Build distribution packages


### PR DESCRIPTION
The current condition makes the job skip unless there is a failure, which means we also skip on success, which is not right, as we want this job to succeed if the matrix job succeeds.

To fix this, we only skip if the `nox-cross-arch` matrix job was skipped and we run otherwise, failing the job if the matrix job was not successful. We also use the job name explicitly, as we only have one dependency and it is easier to reason about a string than about arrays.

For consistency reasons, and to avoid future surprises, we also make the `nox-all` job run on failures of its child jobs, even when it is not necessary for now as we are not skipping jobs in the `nox` matrix job.
