### PR TITLE
mkdocs: Use symlink alias types

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,7 @@
 - The generated docs now show the symbol type in the table of contents.
 - The dependecies were updated to the latest versions.
 - Disabled some `pylint` checks that are already checked by other tools.
+- The generated documentation now uses symlinks for aliases, which allows deep linking when using aliases too.
 
 ## Bug Fixes
 

--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -89,5 +89,10 @@ sed -i -e '/  "unsubscriptable-object",/a \  # Checked by mypy\
   -e '/  "line-too-long",/a \  "missing-function-docstring",' \
   pyproject.toml
 
+echo "========================================================================"
+
+echo "Using symlink aliases in 'mkdocs.yml'"
+sed -i "s|alias_type: redirect|alias_type: symlink|" mkdocs.yml
+
 # Add a separation line like this one after each migration step.
 echo "========================================================================"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -97,7 +97,7 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
   - mike:
-      alias_type: redirect
+      alias_type: symlink
       canonical_version: latest
   - mkdocstrings:
       default_handler: python

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
@@ -97,7 +97,7 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
   - mike:
-      alias_type: redirect
+      alias_type: symlink
       canonical_version: latest
   - mkdocstrings:
       default_handler: python

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
@@ -97,7 +97,7 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
   - mike:
-      alias_type: redirect
+      alias_type: symlink
       canonical_version: latest
   - mkdocstrings:
       default_handler: python

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
@@ -97,7 +97,7 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
   - mike:
-      alias_type: redirect
+      alias_type: symlink
       canonical_version: latest
   - mkdocstrings:
       default_handler: python

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
@@ -97,7 +97,7 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
   - mike:
-      alias_type: redirect
+      alias_type: symlink
       canonical_version: latest
   - mkdocstrings:
       default_handler: python

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
@@ -97,7 +97,7 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
   - mike:
-      alias_type: redirect
+      alias_type: symlink
       canonical_version: latest
   - mkdocstrings:
       default_handler: python


### PR DESCRIPTION
Using symlinks allow deep linking into a particular version of the documentation.
