### PR TITLE
Fix credentials not passed or configured the CI workflow

### DIFF
--- a/.github/containers/test-installation/Dockerfile
+++ b/.github/containers/test-installation/Dockerfile
@@ -14,5 +14,8 @@ RUN apt-get update -y && \
     python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
-RUN pip install dist/*.whl && \
-    rm -rf dist
+# This git-credentials file is made available by the GitHub ci.yaml workflow
+COPY git-credentials /root/.git-credentials
+RUN git config --global credential.helper store && \
+    pip install dist/*.whl && \
+    rm -rf dist /root/.git-credentials

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,10 +43,6 @@ jobs:
     steps:
       - name: Setup Git
         uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
 
       - name: Print environment (debug)
         run: env
@@ -128,10 +124,6 @@ jobs:
     steps:
       - name: Setup Git
         uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
 
       - name: Fetch sources
         uses: actions/checkout@v4
@@ -236,10 +228,6 @@ jobs:
     steps:
       - name: Setup Git
         uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
 
       - name: Fetch sources
         uses: actions/checkout@v4
@@ -275,10 +263,6 @@ jobs:
     steps:
       - name: Setup Git
         uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
 
       - name: Fetch sources
         uses: actions/checkout@v4
@@ -316,10 +300,6 @@ jobs:
     steps:
       - name: Setup Git
         uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
 
       - name: Fetch sources
         uses: actions/checkout@v4
@@ -362,10 +342,6 @@ jobs:
     steps:
       - name: Setup Git
         uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
 
       - name: Fetch sources
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Print environment (debug)
         run: env
 
@@ -119,6 +126,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
 
@@ -220,6 +234,13 @@ jobs:
     name: Build distribution packages
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -252,17 +273,33 @@ jobs:
     needs: ["build"]
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
+
       - name: Download package
         uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
+
+      - name: Make Git credentials available to docker
+        run: |
+          touch ~/.git-credentials  # Ensure the file exists
+          cp ~/.git-credentials git-credentials || true
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up docker-buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Test Installation
         uses: docker/build-push-action@v6
         with:
@@ -277,13 +314,17 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -319,13 +360,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,3 +52,5 @@
 
 - Fixed a bug where the pip cache post action fails in the CI workflow because of permissions issues.
 - Make the `nox-cross-arch-all` job fail if any `nox-cross-arch` matrix job fails.
+- Fix credentials not being passed to the `test-installation` job in the CI workflow.
+- Make sure credentials are configured for all jobs that check out the repository in the CI workflow.

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/containers/test-installation/Dockerfile
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/containers/test-installation/Dockerfile
@@ -15,6 +15,9 @@ RUN apt-get update -y && \
     python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
-RUN pip install dist/*.whl && \
-    rm -rf dist
+# This git-credentials file is made available by the GitHub ci.yaml workflow
+COPY git-credentials /root/.git-credentials
+RUN git config --global credential.helper store && \
+    pip install dist/*.whl && \
+    rm -rf dist /root/.git-credentials
 {%- endraw %}

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -302,13 +302,17 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -346,13 +350,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -318,6 +318,10 @@ jobs:
         with:
           name: dist-packages
           path: dist
+      - name: Make Git credentials available to docker
+        run: |
+          touch ~/.git-credentials  # Ensure the file exists
+          cp ~/.git-credentials git-credentials || true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up docker-buildx

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -311,21 +311,27 @@ jobs:
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
+
       - name: Download package
         uses: actions/download-artifact@v3
         with:
           name: dist-packages
           path: dist
+
       - name: Make Git credentials available to docker
         run: |
           touch ~/.git-credentials  # Ensure the file exists
           cp ~/.git-credentials git-credentials || true
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up docker-buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Test Installation
         uses: docker/build-push-action@v5
         with:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -31,6 +31,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v3
         with:
@@ -67,6 +74,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Print environment (debug)
         run: env
 
@@ -145,6 +159,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -245,6 +266,13 @@ jobs:
     name: Build distribution packages
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -277,6 +305,12 @@ jobs:
     needs: ["build"]
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
       - name: Fetch sources
         uses: actions/checkout@v4
       - name: Download package

--- a/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
@@ -4,6 +4,10 @@
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./CODEOWNERS:* TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)# Temporary, should probably change

--- a/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
@@ -2,6 +2,8 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./CODEOWNERS:* TODO(cookiecutter): Add codeowners (like @{github_org}/some-team)# Temporary, should probably change

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/containers/test-installation/Dockerfile
@@ -13,5 +13,8 @@ RUN apt-get update -y && \
     python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
-RUN pip install dist/*.whl && \
-    rm -rf dist
+# This git-credentials file is made available by the GitHub ci.yaml workflow
+COPY git-credentials /root/.git-credentials
+RUN git config --global credential.helper store && \
+    pip install dist/*.whl && \
+    rm -rf dist /root/.git-credentials

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -285,6 +285,10 @@ jobs:
         with:
           name: dist-packages
           path: dist
+      - name: Make Git credentials available to docker
+        run: |
+          touch ~/.git-credentials  # Ensure the file exists
+          cp ~/.git-credentials git-credentials || true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up docker-buildx

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -276,13 +276,17 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -318,13 +322,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -41,6 +41,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Print environment (debug)
         run: env
 
@@ -119,6 +126,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -219,6 +233,13 @@ jobs:
     name: Build distribution packages
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -251,6 +272,12 @@ jobs:
     needs: ["build"]
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
       - name: Fetch sources
         uses: actions/checkout@v4
       - name: Download package

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -278,21 +278,27 @@ jobs:
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
+
       - name: Download package
         uses: actions/download-artifact@v3
         with:
           name: dist-packages
           path: dist
+
       - name: Make Git credentials available to docker
         run: |
           touch ~/.git-credentials  # Ensure the file exists
           cp ~/.git-credentials git-credentials || true
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up docker-buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Test Installation
         uses: docker/build-push-action@v5
         with:

--- a/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
@@ -4,6 +4,11 @@
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file

--- a/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
@@ -2,6 +2,8 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/containers/test-installation/Dockerfile
@@ -13,5 +13,8 @@ RUN apt-get update -y && \
     python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
-RUN pip install dist/*.whl && \
-    rm -rf dist
+# This git-credentials file is made available by the GitHub ci.yaml workflow
+COPY git-credentials /root/.git-credentials
+RUN git config --global credential.helper store && \
+    pip install dist/*.whl && \
+    rm -rf dist /root/.git-credentials

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -308,21 +308,27 @@ jobs:
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
+
       - name: Download package
         uses: actions/download-artifact@v3
         with:
           name: dist-packages
           path: dist
+
       - name: Make Git credentials available to docker
         run: |
           touch ~/.git-credentials  # Ensure the file exists
           cp ~/.git-credentials git-credentials || true
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up docker-buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Test Installation
         uses: docker/build-push-action@v5
         with:

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -299,13 +299,17 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -341,13 +345,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -29,6 +29,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v3
         with:
@@ -64,6 +71,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Print environment (debug)
         run: env
 
@@ -142,6 +156,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -242,6 +263,13 @@ jobs:
     name: Build distribution packages
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -274,6 +302,12 @@ jobs:
     needs: ["build"]
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
       - name: Fetch sources
         uses: actions/checkout@v4
       - name: Download package

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -315,6 +315,10 @@ jobs:
         with:
           name: dist-packages
           path: dist
+      - name: Make Git credentials available to docker
+        run: |
+          touch ~/.git-credentials  # Ensure the file exists
+          cp ~/.git-credentials git-credentials || true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up docker-buildx

--- a/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
@@ -4,6 +4,10 @@
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file

--- a/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
@@ -2,6 +2,8 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/containers/test-installation/Dockerfile
@@ -13,5 +13,8 @@ RUN apt-get update -y && \
     python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
-RUN pip install dist/*.whl && \
-    rm -rf dist
+# This git-credentials file is made available by the GitHub ci.yaml workflow
+COPY git-credentials /root/.git-credentials
+RUN git config --global credential.helper store && \
+    pip install dist/*.whl && \
+    rm -rf dist /root/.git-credentials

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -285,6 +285,10 @@ jobs:
         with:
           name: dist-packages
           path: dist
+      - name: Make Git credentials available to docker
+        run: |
+          touch ~/.git-credentials  # Ensure the file exists
+          cp ~/.git-credentials git-credentials || true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up docker-buildx

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -276,13 +276,17 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -318,13 +322,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -41,6 +41,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Print environment (debug)
         run: env
 
@@ -119,6 +126,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -219,6 +233,13 @@ jobs:
     name: Build distribution packages
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -251,6 +272,12 @@ jobs:
     needs: ["build"]
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
       - name: Fetch sources
         uses: actions/checkout@v4
       - name: Download package

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -278,21 +278,27 @@ jobs:
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
+
       - name: Download package
         uses: actions/download-artifact@v3
         with:
           name: dist-packages
           path: dist
+
       - name: Make Git credentials available to docker
         run: |
           touch ~/.git-credentials  # Ensure the file exists
           cp ~/.git-credentials git-credentials || true
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up docker-buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Test Installation
         uses: docker/build-push-action@v5
         with:

--- a/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
@@ -4,6 +4,10 @@
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file

--- a/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
@@ -2,6 +2,8 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/containers/test-installation/Dockerfile
@@ -13,5 +13,8 @@ RUN apt-get update -y && \
     python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
-RUN pip install dist/*.whl && \
-    rm -rf dist
+# This git-credentials file is made available by the GitHub ci.yaml workflow
+COPY git-credentials /root/.git-credentials
+RUN git config --global credential.helper store && \
+    pip install dist/*.whl && \
+    rm -rf dist /root/.git-credentials

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -285,6 +285,10 @@ jobs:
         with:
           name: dist-packages
           path: dist
+      - name: Make Git credentials available to docker
+        run: |
+          touch ~/.git-credentials  # Ensure the file exists
+          cp ~/.git-credentials git-credentials || true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up docker-buildx

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -276,13 +276,17 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -318,13 +322,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -41,6 +41,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Print environment (debug)
         run: env
 
@@ -119,6 +126,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -219,6 +233,13 @@ jobs:
     name: Build distribution packages
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -251,6 +272,12 @@ jobs:
     needs: ["build"]
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
       - name: Fetch sources
         uses: actions/checkout@v4
       - name: Download package

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -278,21 +278,27 @@ jobs:
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
+
       - name: Download package
         uses: actions/download-artifact@v3
         with:
           name: dist-packages
           path: dist
+
       - name: Make Git credentials available to docker
         run: |
           touch ~/.git-credentials  # Ensure the file exists
           cp ~/.git-credentials git-credentials || true
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up docker-buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Test Installation
         uses: docker/build-push-action@v5
         with:

--- a/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
@@ -4,6 +4,10 @@
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file

--- a/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
@@ -2,6 +2,8 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/release-notes-check.yml:          # TODO(cookiecutter): Uncomment the following line for private repositories, otherwise remove it and remove it
 ./CODEOWNERS:# TODO(cookiecutter): Add more specific code-owners, check if the default is correct
 ./README.md:TODO(cookiecutter): Improve the README file

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/containers/test-installation/Dockerfile
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/containers/test-installation/Dockerfile
@@ -13,5 +13,8 @@ RUN apt-get update -y && \
     python -m pip install --upgrade --no-cache-dir pip
 
 COPY dist dist
-RUN pip install dist/*.whl && \
-    rm -rf dist
+# This git-credentials file is made available by the GitHub ci.yaml workflow
+COPY git-credentials /root/.git-credentials
+RUN git config --global credential.helper store && \
+    pip install dist/*.whl && \
+    rm -rf dist /root/.git-credentials

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -285,6 +285,10 @@ jobs:
         with:
           name: dist-packages
           path: dist
+      - name: Make Git credentials available to docker
+        run: |
+          touch ~/.git-credentials  # Ensure the file exists
+          cp ~/.git-credentials git-credentials || true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up docker-buildx

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -276,13 +276,17 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -318,13 +322,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup Git user and e-mail
-        uses: frequenz-floss/setup-git-user@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -41,6 +41,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Print environment (debug)
         run: env
 
@@ -119,6 +126,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -219,6 +233,13 @@ jobs:
     name: Build distribution packages
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
@@ -251,6 +272,12 @@ jobs:
     needs: ["build"]
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
       - name: Fetch sources
         uses: actions/checkout@v4
       - name: Download package

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -278,21 +278,27 @@ jobs:
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
+
       - name: Fetch sources
         uses: actions/checkout@v4
+
       - name: Download package
         uses: actions/download-artifact@v3
         with:
           name: dist-packages
           path: dist
+
       - name: Make Git credentials available to docker
         run: |
           touch ~/.git-credentials  # Ensure the file exists
           cp ~/.git-credentials git-credentials || true
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up docker-buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Test Installation
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
- **Replace the old `setup-git-user` step with `gh-action-setup-git`**
- **Add a `gh-action-setup-git` step to every job doing a checkout**
- **ci: Pass git credentials to the `test-installation` job**
- **Improve spacing of the test-installation job**
- **Add migration steps to the migration script**
- **Apply the migration script to this repository**
- **Remove the TODOs from the migration**
- **Update release notes**

Fixes #278.
