### PR TITLE
Disable the new `check-class-attributes` check in pydoclint 0.5.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -54,3 +54,4 @@
 - Make the `nox-cross-arch-all` job fail if any `nox-cross-arch` matrix job fails.
 - Fix credentials not being passed to the `test-installation` job in the CI workflow.
 - Make sure credentials are configured for all jobs that check out the repository in the CI workflow.
+- Disable the new `check-class-attributes` check in pydoclint 0.5.3, as we use a different way to document class attributes.

--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -241,5 +241,10 @@ EOF
 manual_step "Please make sure to remove or uncomment the options to the 'gh-action-setup-git' action in the '.github/workflows/ci.yaml'"
 grep -n "TODO(cookiecutter)" -- .github/workflows/ci.yaml .github/containers/test-installation/Dockerfile
 
+echo "========================================================================"
+
+echo "Disabling new pydoclint's check-class-attributes check in "
+sed -i "/^allow-init-docstring/a check-class-attributes = false" pyproject.toml
+
 # Add a separation line like this one after each migration step.
 echo "========================================================================"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -148,6 +148,7 @@ check-yield-types = false
 arg-type-hints-in-docstring = false
 arg-type-hints-in-signature = true
 allow-init-docstring = true
+check-class-attributes = false
 
 [tool.pylint.similarities]
 ignore-comments = ['yes']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ check-yield-types = false
 arg-type-hints-in-docstring = false
 arg-type-hints-in-signature = true
 allow-init-docstring = true
+check-class-attributes = false
 
 [tool.pylint.similarities]
 ignore-comments = ['yes']

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -122,6 +122,7 @@ check-yield-types = false
 arg-type-hints-in-docstring = false
 arg-type-hints-in-signature = true
 allow-init-docstring = true
+check-class-attributes = false
 
 [tool.pylint.similarities]
 ignore-comments = ['yes']

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -117,6 +117,7 @@ check-yield-types = false
 arg-type-hints-in-docstring = false
 arg-type-hints-in-signature = true
 allow-init-docstring = true
+check-class-attributes = false
 
 [tool.pylint.similarities]
 ignore-comments = ['yes']

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -121,6 +121,7 @@ check-yield-types = false
 arg-type-hints-in-docstring = false
 arg-type-hints-in-signature = true
 allow-init-docstring = true
+check-class-attributes = false
 
 [tool.pylint.similarities]
 ignore-comments = ['yes']

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -118,6 +118,7 @@ check-yield-types = false
 arg-type-hints-in-docstring = false
 arg-type-hints-in-signature = true
 allow-init-docstring = true
+check-class-attributes = false
 
 [tool.pylint.similarities]
 ignore-comments = ['yes']

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -122,6 +122,7 @@ check-yield-types = false
 arg-type-hints-in-docstring = false
 arg-type-hints-in-signature = true
 allow-init-docstring = true
+check-class-attributes = false
 
 [tool.pylint.similarities]
 ignore-comments = ['yes']


### PR DESCRIPTION
We use a different way to document class attributes, so this check is not useful for us.
