### PR TITLE
Add pull-requests read permission to the release-notes-check workflow

### DIFF
--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -17,6 +17,8 @@ jobs:
   check-release-notes:
     name: Check release notes are updated
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check for a release notes update
         if: github.event_name == 'pull_request'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -55,3 +55,4 @@
 - Fix credentials not being passed to the `test-installation` job in the CI workflow.
 - Make sure credentials are configured for all jobs that check out the repository in the CI workflow.
 - Disable the new `check-class-attributes` check in pydoclint 0.5.3, as we use a different way to document class attributes.
+- Fix permissions issues with the `release-notes-check` workflow when the repository Actions configuration is set up without full access.

--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -246,5 +246,24 @@ echo "========================================================================"
 echo "Disabling new pydoclint's check-class-attributes check in "
 sed -i "/^allow-init-docstring/a check-class-attributes = false" pyproject.toml
 
+echo "========================================================================"
+
+echo "Adding pull-requests read permission to the release-notes-check workflow"
+patch --merge -p1 <<'EOF'
+diff --git a/.github/workflows/release-notes-check.yml b/.github/workflows/release-notes-check.yml
+index 1e35c1a..e97886b 100644
+--- a/.github/workflows/release-notes-check.yml
++++ b/.github/workflows/release-notes-check.yml
+@@ -17,6 +17,8 @@ jobs:
+   check-release-notes:
+     name: Check release notes are updated
+     runs-on: ubuntu-latest
++    permissions:
++      pull-requests: read
+     steps:
+       - name: Check for a release notes update
+         if: github.event_name == 'pull_request'
+EOF
+
 # Add a separation line like this one after each migration step.
 echo "========================================================================"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/release-notes-check.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/release-notes-check.yml
@@ -17,6 +17,8 @@ jobs:
   check-release-notes:
     name: Check release notes are updated
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check for a release notes update
         if: github.event_name == 'pull_request'

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/release-notes-check.yml
@@ -17,6 +17,8 @@ jobs:
   check-release-notes:
     name: Check release notes are updated
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check for a release notes update
         if: github.event_name == 'pull_request'

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/release-notes-check.yml
@@ -17,6 +17,8 @@ jobs:
   check-release-notes:
     name: Check release notes are updated
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check for a release notes update
         if: github.event_name == 'pull_request'

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/release-notes-check.yml
@@ -17,6 +17,8 @@ jobs:
   check-release-notes:
     name: Check release notes are updated
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check for a release notes update
         if: github.event_name == 'pull_request'

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/release-notes-check.yml
@@ -17,6 +17,8 @@ jobs:
   check-release-notes:
     name: Check release notes are updated
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check for a release notes update
         if: github.event_name == 'pull_request'

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/release-notes-check.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/release-notes-check.yml
@@ -17,6 +17,8 @@ jobs:
   check-release-notes:
     name: Check release notes are updated
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check for a release notes update
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This is necessary when the repository Actions configuration is set up without full access by default. In this case, the only access provided is `contents: read`, but this action needs to read the pull request too.
