### PR TITLE
Group dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,11 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,7 +18,7 @@
 
 ### Cookiecutter template
 
-<!-- Here new features for cookiecutter specifically -->
+* Group GitHub Actions dependabot updates.
 
 ## Bug Fixes
 

--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -22,9 +22,27 @@ manual_step() {
   echo "\033[0;33m>>> $@\033[0m"
 }
 
-echo "TODO: Describe your migration step here."
+#echo "TODO: Describe your migration step here."
 # Add your migration steps here.
-manual_step "Add any manual instructions for this step here."
+#manual_step "Add any manual instructions for this step here."
+
+echo "dependabot: Group GitHub Actions updates."
+cat <<'EOT' | patch -p1
+--- a/.github/dependabot.yml
++++ b/.github/dependabot.yml
+@@ -39,3 +39,11 @@ updates:
+     labels:
+       - "part:tooling"
+       - "type:tech-debt"
++    groups:
++      compatible:
++        update-types:
++          - "minor"
++          - "patch"
++      artifacts:
++        patterns:
++          - "actions/*-artifact"
+EOT
 
 # Add a separation line like this one after each migration step.
 echo "========================================================================"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
@@ -39,6 +39,14 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"
 {%- if cookiecutter.type == "api" %}
 
   - package-ecosystem: "gitsubmodule"

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
@@ -39,3 +39,11 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
@@ -39,6 +39,14 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
@@ -39,3 +39,11 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
@@ -39,3 +39,11 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
@@ -39,3 +39,11 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"


### PR DESCRIPTION
Group patch and minor updates, as well as any release for the upload/download artifact actions, that need to be upgraded always together.
