### PR TITLE
Fix the labeler configuration example

### DIFF
--- a/cookiecutter/migrate.sh
+++ b/cookiecutter/migrate.sh
@@ -44,5 +44,10 @@ cat <<'EOT' | patch -p1
 +          - "actions/*-artifact"
 EOT
 
+echo "========================================================================"
+
+echo "Fix the labeler configuration example."
+perl -i -pe 's/all-glob-to-all-file/all-globs-to-all-files/g' .github/labeler.yml
+
 # Add a separation line like this one after each migration step.
 echo "========================================================================"

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/labeler.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/labeler.yml
@@ -26,7 +26,7 @@
 #     - changed-files:
 #       - any-glob-to-any-file:
 #         - "src/**/*.py"
-#       - all-glob-to-all-file:
+#       - all-globs-to-all-files:
 #         - "!src/__init__.py"
 #
 # Please have in mind that that the part:xxx labels need to

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/labeler.yml
@@ -26,7 +26,7 @@
 #     - changed-files:
 #       - any-glob-to-any-file:
 #         - "src/**/*.py"
-#       - all-glob-to-all-file:
+#       - all-globs-to-all-files:
 #         - "!src/__init__.py"
 #
 # Please have in mind that that the part:xxx labels need to

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/labeler.yml
@@ -26,7 +26,7 @@
 #     - changed-files:
 #       - any-glob-to-any-file:
 #         - "src/**/*.py"
-#       - all-glob-to-all-file:
+#       - all-globs-to-all-files:
 #         - "!src/__init__.py"
 #
 # Please have in mind that that the part:xxx labels need to

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/labeler.yml
@@ -26,7 +26,7 @@
 #     - changed-files:
 #       - any-glob-to-any-file:
 #         - "src/**/*.py"
-#       - all-glob-to-all-file:
+#       - all-globs-to-all-files:
 #         - "!src/__init__.py"
 #
 # Please have in mind that that the part:xxx labels need to

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/labeler.yml
@@ -26,7 +26,7 @@
 #     - changed-files:
 #       - any-glob-to-any-file:
 #         - "src/**/*.py"
-#       - all-glob-to-all-file:
+#       - all-globs-to-all-files:
 #         - "!src/__init__.py"
 #
 # Please have in mind that that the part:xxx labels need to

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/labeler.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/labeler.yml
@@ -26,7 +26,7 @@
 #     - changed-files:
 #       - any-glob-to-any-file:
 #         - "src/**/*.py"
-#       - all-glob-to-all-file:
+#       - all-globs-to-all-files:
 #         - "!src/__init__.py"
 #
 # Please have in mind that that the part:xxx labels need to


### PR DESCRIPTION
The labeler configuration example was using a wrong key, it should be `all-globs-to-all-files` instead of `all-glob-to-all-file`.

Note we use `perl` instead of `sed` in the migration script because it is more portable and we don't need to worry about the differences between the different `sed` implementations (refs #302).
