### PR TITLE
Bump SDK dependency to 1.0.0rc901

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@
 * API projects don't include the `google-common-protos` dependency by default.
 * API projects updated the `grpcio` dependency to `1.66.1`.
 * API projects updated the `frequenz-api-common` dependency to `0.6`.
+* Update the SDK dependency to `1.0.0rc901`.
 * Change `edit_uri` default branch to v0.x.x in mkdocs.yml.
 
 ## Bug Fixes

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -121,8 +121,8 @@ plugins:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
 {%- if cookiecutter.type in ("actor", "app", "model") %}
-            - https://frequenz-floss.github.io/frequenz-channels-python/v0.16/objects.inv
-            - https://frequenz-floss.github.io/frequenz-sdk-python/v0.25/objects.inv
+            - https://frequenz-floss.github.io/frequenz-channels-python/v1/objects.inv
+            - https://frequenz-floss.github.io/frequenz-sdk-python/v1.0-pre/objects.inv
 {%- elif cookiecutter.type == "api" %}
             - https://frequenz-floss.github.io/frequenz-api-common/v0.6/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -44,11 +44,11 @@ requires-python = ">= 3.11, < 4"
 # TODO(cookiecutter): Remove and add more dependencies if appropriate
 {%- if cookiecutter.type in ("app", "actor", "model") %}
 dependencies = [
-  "typing-extensions == 4.5.0",
+  "typing-extensions == 4.6.1",
   # Make sure to update the version for cross-referencing also in the
   # mkdocs.yml file when changing the version here (look for the config key
   # plugins.mkdocstrings.handlers.python.import)
-  "frequenz-sdk == 0.25.0",
+  "frequenz-sdk >= 1.0.0rc901, < 1.0.0rc1000",
 ]
 {%- elif cookiecutter.type == "api" %}
 dependencies = [

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
@@ -120,8 +120,8 @@ plugins:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
-            - https://frequenz-floss.github.io/frequenz-channels-python/v0.16/objects.inv
-            - https://frequenz-floss.github.io/frequenz-sdk-python/v0.25/objects.inv
+            - https://frequenz-floss.github.io/frequenz-channels-python/v1/objects.inv
+            - https://frequenz-floss.github.io/frequenz-sdk-python/v1.0-pre/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   # Note this plugin must be loaded after mkdocstrings to be able to use macros
   # inside docstrings. See the comment in `docs/_scripts/macros.py` for more

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -28,11 +28,11 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 # TODO(cookiecutter): Remove and add more dependencies if appropriate
 dependencies = [
-  "typing-extensions == 4.5.0",
+  "typing-extensions == 4.6.1",
   # Make sure to update the version for cross-referencing also in the
   # mkdocs.yml file when changing the version here (look for the config key
   # plugins.mkdocstrings.handlers.python.import)
-  "frequenz-sdk == 0.25.0",
+  "frequenz-sdk >= 1.0.0rc901, < 1.0.0rc1000",
 ]
 dynamic = ["version"]
 

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
@@ -120,8 +120,8 @@ plugins:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
-            - https://frequenz-floss.github.io/frequenz-channels-python/v0.16/objects.inv
-            - https://frequenz-floss.github.io/frequenz-sdk-python/v0.25/objects.inv
+            - https://frequenz-floss.github.io/frequenz-channels-python/v1/objects.inv
+            - https://frequenz-floss.github.io/frequenz-sdk-python/v1.0-pre/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   # Note this plugin must be loaded after mkdocstrings to be able to use macros
   # inside docstrings. See the comment in `docs/_scripts/macros.py` for more

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -27,11 +27,11 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 # TODO(cookiecutter): Remove and add more dependencies if appropriate
 dependencies = [
-  "typing-extensions == 4.5.0",
+  "typing-extensions == 4.6.1",
   # Make sure to update the version for cross-referencing also in the
   # mkdocs.yml file when changing the version here (look for the config key
   # plugins.mkdocstrings.handlers.python.import)
-  "frequenz-sdk == 0.25.0",
+  "frequenz-sdk >= 1.0.0rc901, < 1.0.0rc1000",
 ]
 dynamic = ["version"]
 

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
@@ -120,8 +120,8 @@ plugins:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
-            - https://frequenz-floss.github.io/frequenz-channels-python/v0.16/objects.inv
-            - https://frequenz-floss.github.io/frequenz-sdk-python/v0.25/objects.inv
+            - https://frequenz-floss.github.io/frequenz-channels-python/v1/objects.inv
+            - https://frequenz-floss.github.io/frequenz-sdk-python/v1.0-pre/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   # Note this plugin must be loaded after mkdocstrings to be able to use macros
   # inside docstrings. See the comment in `docs/_scripts/macros.py` for more

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -28,11 +28,11 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 # TODO(cookiecutter): Remove and add more dependencies if appropriate
 dependencies = [
-  "typing-extensions == 4.5.0",
+  "typing-extensions == 4.6.1",
   # Make sure to update the version for cross-referencing also in the
   # mkdocs.yml file when changing the version here (look for the config key
   # plugins.mkdocstrings.handlers.python.import)
-  "frequenz-sdk == 0.25.0",
+  "frequenz-sdk >= 1.0.0rc901, < 1.0.0rc1000",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
We also need to bump the documentation references to the SDK to the new version and the channels too, as the SDK now depends on 1.1.x, and the `typing-extensions` dependency to 4.6.1, as it is the minimum version required by the SDK.
