### PR TITLE
Add `asyncio_default_fixture_loop_scope = "function"` option

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@
 * API projects updated the `frequenz-api-common` dependency to `0.6`.
 * Update the SDK dependency to `1.0.0rc901`.
 * Change `edit_uri` default branch to v0.x.x in mkdocs.yml.
+* Added a new default option `asyncio_default_fixture_loop_scope = "function"` for `pytest-asyncio` as not providing a value is deprecated.
 
 ## Bug Fixes
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -119,7 +119,7 @@ dev-pytest = [
   "frequenz-repo-config[extra-lint-examples] == 0.10.0",
 {%- if cookiecutter.type != "api" %}
   "pytest-mock == 3.14.0",
-  "pytest-asyncio == 0.23.7",
+  "pytest-asyncio == 0.24.0",
   "async-solipsism == 0.6",
 {%- endif %}
 ]

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -197,6 +197,7 @@ disable = [
 {%- if cookiecutter.type != "api" %}
 testpaths = ["tests", "src"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 {%- else %}
 testpaths = ["pytests"]

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -82,7 +82,7 @@ dev-pytest = [
   "pylint == 3.2.5",       # We need this to check for the examples
   "frequenz-repo-config[extra-lint-examples] == 0.10.0",
   "pytest-mock == 3.14.0",
-  "pytest-asyncio == 0.23.7",
+  "pytest-asyncio == 0.24.0",
   "async-solipsism == 0.6",
 ]
 dev = [

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -155,6 +155,7 @@ disable = [
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 
 [tool.mypy]

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -81,7 +81,7 @@ dev-pytest = [
   "pylint == 3.2.5",       # We need this to check for the examples
   "frequenz-repo-config[extra-lint-examples] == 0.10.0",
   "pytest-mock == 3.14.0",
-  "pytest-asyncio == 0.23.7",
+  "pytest-asyncio == 0.24.0",
   "async-solipsism == 0.6",
 ]
 dev = [

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -154,6 +154,7 @@ disable = [
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 
 [tool.mypy]

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -151,6 +151,7 @@ disable = [
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 
 [tool.mypy]

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -78,7 +78,7 @@ dev-pytest = [
   "pylint == 3.2.5",       # We need this to check for the examples
   "frequenz-repo-config[extra-lint-examples] == 0.10.0",
   "pytest-mock == 3.14.0",
-  "pytest-asyncio == 0.23.7",
+  "pytest-asyncio == 0.24.0",
   "async-solipsism == 0.6",
 ]
 dev = [

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -82,7 +82,7 @@ dev-pytest = [
   "pylint == 3.2.5",       # We need this to check for the examples
   "frequenz-repo-config[extra-lint-examples] == 0.10.0",
   "pytest-mock == 3.14.0",
-  "pytest-asyncio == 0.23.7",
+  "pytest-asyncio == 0.24.0",
   "async-solipsism == 0.6",
 ]
 dev = [

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -155,6 +155,7 @@ disable = [
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 
 [tool.mypy]


### PR DESCRIPTION
`pytest-asyncio` has deprecated not providing a value for the `asyncio_default_fixture_loop_scope` option. This commit adds a default value of `"function"` for this option, as it was the previous default, in the `pyproject.toml` files of this and all the generated projects.
