### PR TITLE
Disable more pylint checks that are also checked by mypy

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@
 * Change `edit_uri` default branch to v0.x.x in mkdocs.yml.
 * Added a new default option `asyncio_default_fixture_loop_scope = "function"` for `pytest-asyncio` as not providing a value is deprecated.
 * The migration script is now written in Python, so it should be (hopefully) more compatible with different OSes.
+* Disable more `pylint` checks that are also checked by `mypy` to avoid false positives.
 
 ## Bug Fixes
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -178,11 +178,11 @@ disable = [
   # disabled because it conflicts with isort
   "wrong-import-order",
   "ungrouped-imports",
-  # pylint's unsubscriptable check is buggy and is not needed because
-  # it is a type-check, for which we already have mypy.
+  # Checked by mypy (and pylint is very flaky checking these)
   "unsubscriptable-object",
-  # Checked by mypy
   "no-member",
+  "no-name-in-module",
+  "possibly-used-before-assignment",
   # Checked by flake8
   "f-string-without-interpolation",
   "line-too-long",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,10 +167,11 @@ disable = [
   # disabled because it conflicts with isort
   "wrong-import-order",
   "ungrouped-imports",
-  # pylint's unsubscriptable check is buggy and is not needed because
-  # it is a type-check, for which we already have mypy.
+  # Checked by mypy (and pylint is very flaky checking these)
   "unsubscriptable-object",
   "no-member",
+  "no-name-in-module",
+  "possibly-used-before-assignment",
   # Checked by flake8
   "f-string-without-interpolation",
   "line-too-long",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,8 +170,11 @@ disable = [
   # pylint's unsubscriptable check is buggy and is not needed because
   # it is a type-check, for which we already have mypy.
   "unsubscriptable-object",
+  "no-member",
   # Checked by flake8
+  "f-string-without-interpolation",
   "line-too-long",
+  "missing-function-docstring",
   "redefined-outer-name",
   "unnecessary-lambda-assignment",
   "unused-import",

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -137,11 +137,11 @@ disable = [
   # disabled because it conflicts with isort
   "wrong-import-order",
   "ungrouped-imports",
-  # pylint's unsubscriptable check is buggy and is not needed because
-  # it is a type-check, for which we already have mypy.
+  # Checked by mypy (and pylint is very flaky checking these)
   "unsubscriptable-object",
-  # Checked by mypy
   "no-member",
+  "no-name-in-module",
+  "possibly-used-before-assignment",
   # Checked by flake8
   "f-string-without-interpolation",
   "line-too-long",

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -145,11 +145,11 @@ disable = [
   # disabled because it conflicts with isort
   "wrong-import-order",
   "ungrouped-imports",
-  # pylint's unsubscriptable check is buggy and is not needed because
-  # it is a type-check, for which we already have mypy.
+  # Checked by mypy (and pylint is very flaky checking these)
   "unsubscriptable-object",
-  # Checked by mypy
   "no-member",
+  "no-name-in-module",
+  "possibly-used-before-assignment",
   # Checked by flake8
   "f-string-without-interpolation",
   "line-too-long",

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -136,11 +136,11 @@ disable = [
   # disabled because it conflicts with isort
   "wrong-import-order",
   "ungrouped-imports",
-  # pylint's unsubscriptable check is buggy and is not needed because
-  # it is a type-check, for which we already have mypy.
+  # Checked by mypy (and pylint is very flaky checking these)
   "unsubscriptable-object",
-  # Checked by mypy
   "no-member",
+  "no-name-in-module",
+  "possibly-used-before-assignment",
   # Checked by flake8
   "f-string-without-interpolation",
   "line-too-long",

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -133,11 +133,11 @@ disable = [
   # disabled because it conflicts with isort
   "wrong-import-order",
   "ungrouped-imports",
-  # pylint's unsubscriptable check is buggy and is not needed because
-  # it is a type-check, for which we already have mypy.
+  # Checked by mypy (and pylint is very flaky checking these)
   "unsubscriptable-object",
-  # Checked by mypy
   "no-member",
+  "no-name-in-module",
+  "possibly-used-before-assignment",
   # Checked by flake8
   "f-string-without-interpolation",
   "line-too-long",

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -137,11 +137,11 @@ disable = [
   # disabled because it conflicts with isort
   "wrong-import-order",
   "ungrouped-imports",
-  # pylint's unsubscriptable check is buggy and is not needed because
-  # it is a type-check, for which we already have mypy.
+  # Checked by mypy (and pylint is very flaky checking these)
   "unsubscriptable-object",
-  # Checked by mypy
   "no-member",
+  "no-name-in-module",
+  "possibly-used-before-assignment",
   # Checked by flake8
   "f-string-without-interpolation",
   "line-too-long",


### PR DESCRIPTION
`pylint` has some false positive for these checks, so better to just rely on `mypy` for them.
