### PR TITLE
Add notes to the upgrading section and a comment that the script finished

### DIFF
--- a/.github/cookiecutter-migrate.template.py
+++ b/.github/cookiecutter-migrate.template.py
@@ -32,6 +32,8 @@ def main() -> None:
     """Run the migration steps."""
     # Add a separation line like this one after each migration step.
     print("=" * 72)
+    print("Migration script finished. Remember to follow any manual instructions.")
+    print("=" * 72)
 
 
 def apply_patch(patch_content: str) -> None:

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -32,6 +32,8 @@ def main() -> None:
     """Run the migration steps."""
     # Add a separation line like this one after each migration step.
     print("=" * 72)
+    print("Migration script finished. Remember to follow any manual instructions.")
+    print("=" * 72)
 
 
 def apply_patch(patch_content: str) -> None:

--- a/docs/user-guide/update-an-existing-project.md
+++ b/docs/user-guide/update-an-existing-project.md
@@ -29,6 +29,30 @@ curl -sSL https://raw.githubusercontent.com/frequenz-floss/frequenz-repo-config-
 Make sure that the version (`{{ ref_name }}`) matches the
 target version you are migrating to.
 
+!!! Tip "Tip for MacOS users"
+
+    The migration script may not work out of the box on macOS. You need to
+    install `coreutils` to ensure compatibility:
+
+    ```sh
+    brew install coreutils gnu-sed
+    ```
+
+    After installation, update your `PATH` in your shell configuration
+    (e.g. ~/.zshrc) so that the system uses the GNU versions. Depending on
+    where the packages are installed this might look like this:
+
+    ```sh
+    export PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
+    export MANPATH="/opt/homebrew/opt/coreutils/libexec/gnuman:$MANPATH"
+    ```
+
+    Then, source your configuration file again to apply the changes:
+
+    ```sh
+    source ~/.zshrc  # or ~/.bashrc, depending on your shell
+    ```
+
 ## Re-run the Cookiecutter command
 
 If you are upgrading a very old project (jumping multiple versions at the time)


### PR DESCRIPTION
This PR introduces tips on how to run the migrate script as a MacOS user and adds a comment at the end of the script execution to let the user know that the migration finished and ran through.
Fixes #353, #354 