### PR TITLE
Update link in cookiecutter end instructions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,37 +1,7 @@
 # Frequenz Repository Configuration Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-### Cookiecutter template
-
-All upgrading should be done via the migration script or regenerating the templates.
-
-```bash
-curl -sSL https://raw.githubusercontent.com/frequenz-floss/frequenz-repo-config-python/v0.12/cookiecutter/migrate.py | python3
-```
-
-But you might still need to adapt your code:
-
-<!-- Here upgrade steps for cookiecutter specifically -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-### Cookiecutter template
-
-<!-- Here new features for cookiecutter specifically -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
-
 ### Cookiecutter template
 
-<!-- Here bug fixes for cookiecutter specifically -->
+- Fixed an outdated link to instructions on how to continue when the cookiecutter template generation finishes.

--- a/cookiecutter/hooks/post_gen_project.py
+++ b/cookiecutter/hooks/post_gen_project.py
@@ -476,8 +476,8 @@ def print_todos() -> None:
     print()
     note(
         "Make sure to (create and) configure your GitHub repository too: "
-        "https://github.com/frequenz-floss/frequenz-repo-config-python/"
-        "wiki/Configuring-a-new-GitHub-repository"
+        "https://frequenz-floss.github.io/frequenz-repo-config-python/"
+        "latest/user-guide/start-a-new-project/configure-github/"
     )
 
 

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 75.8.0",
   "setuptools_scm[toml] == 8.1.0",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.12.2",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.12.3",
 {%- if cookiecutter.type == "api" %}
   # We need to pin the protobuf, grpcio and  grpcio-tools dependencies to make
   # sure the code is generated using the minimum supported versions, as older
@@ -101,7 +101,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.6.2",
   "mkdocstrings[python] == 0.28.0",
   "mkdocstrings-python == 1.14.6",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.12.2",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.12.3",
 ]
 dev-mypy = [
   "mypy == 1.9.0",
@@ -114,7 +114,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2024.10.9",
-  "frequenz-repo-config[{{cookiecutter.type}}] == 0.12.2",
+  "frequenz-repo-config[{{cookiecutter.type}}] == 0.12.3",
 ]
 dev-pylint = [
   # dev-pytest already defines a dependency to pylint because of the examples
@@ -124,7 +124,7 @@ dev-pylint = [
 dev-pytest = [
   "pytest == 8.3.4",
   "pylint == 3.3.4",       # We need this to check for the examples
-  "frequenz-repo-config[extra-lint-examples] == 0.12.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.12.3",
 {%- if cookiecutter.type != "api" %}
   "pytest-mock == 3.14.0",
   "pytest-asyncio == 0.25.3",

--- a/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
@@ -30,7 +30,7 @@
 
 Here is a list of things that should be reviewed and FIXED:
 
-[36mMake sure to (create and) configure your GitHub repository too: https://github.com/frequenz-floss/frequenz-repo-config-python/wiki/Configuring-a-new-GitHub-repository[0m
+[36mMake sure to (create and) configure your GitHub repository too: https://frequenz-floss.github.io/frequenz-repo-config-python/latest/user-guide/start-a-new-project/configure-github/[0m
 
 After completing it you can amend the previous commit using `git commit --amend` or create a new commit for the changes using `git commit`.
 

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 75.8.0",
   "setuptools_scm[toml] == 8.1.0",
-  "frequenz-repo-config[actor] == 0.12.2",
+  "frequenz-repo-config[actor] == 0.12.3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -60,7 +60,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.6.2",
   "mkdocstrings[python] == 0.28.0",
   "mkdocstrings-python == 1.14.6",
-  "frequenz-repo-config[actor] == 0.12.2",
+  "frequenz-repo-config[actor] == 0.12.3",
 ]
 dev-mypy = [
   "mypy == 1.9.0",
@@ -70,7 +70,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2024.10.9",
-  "frequenz-repo-config[actor] == 0.12.2",
+  "frequenz-repo-config[actor] == 0.12.3",
 ]
 dev-pylint = [
   # dev-pytest already defines a dependency to pylint because of the examples
@@ -80,7 +80,7 @@ dev-pylint = [
 dev-pytest = [
   "pytest == 8.3.4",
   "pylint == 3.3.4",       # We need this to check for the examples
-  "frequenz-repo-config[extra-lint-examples] == 0.12.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.12.3",
   "pytest-mock == 3.14.0",
   "pytest-asyncio == 0.25.3",
   "async-solipsism == 0.7",

--- a/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
@@ -29,7 +29,7 @@
 
 Here is a list of things that should be reviewed and FIXED:
 
-[36mMake sure to (create and) configure your GitHub repository too: https://github.com/frequenz-floss/frequenz-repo-config-python/wiki/Configuring-a-new-GitHub-repository[0m
+[36mMake sure to (create and) configure your GitHub repository too: https://frequenz-floss.github.io/frequenz-repo-config-python/latest/user-guide/start-a-new-project/configure-github/[0m
 
 After completing it you can amend the previous commit using `git commit --amend` or create a new commit for the changes using `git commit`.
 

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 75.8.0",
   "setuptools_scm[toml] == 8.1.0",
-  "frequenz-repo-config[api] == 0.12.2",
+  "frequenz-repo-config[api] == 0.12.3",
   # We need to pin the protobuf, grpcio and  grpcio-tools dependencies to make
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
@@ -71,7 +71,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.6.2",
   "mkdocstrings[python] == 0.28.0",
   "mkdocstrings-python == 1.14.6",
-  "frequenz-repo-config[api] == 0.12.2",
+  "frequenz-repo-config[api] == 0.12.3",
 ]
 dev-mypy = [
   "mypy == 1.9.0",
@@ -82,7 +82,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2024.10.9",
-  "frequenz-repo-config[api] == 0.12.2",
+  "frequenz-repo-config[api] == 0.12.3",
 ]
 dev-pylint = [
   # dev-pytest already defines a dependency to pylint because of the examples
@@ -92,7 +92,7 @@ dev-pylint = [
 dev-pytest = [
   "pytest == 8.3.4",
   "pylint == 3.3.4",       # We need this to check for the examples
-  "frequenz-repo-config[extra-lint-examples] == 0.12.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.12.3",
 ]
 dev = [
   "frequenz-api-test[dev-mkdocs,dev-flake8,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",

--- a/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
@@ -29,7 +29,7 @@
 
 Here is a list of things that should be reviewed and FIXED:
 
-[36mMake sure to (create and) configure your GitHub repository too: https://github.com/frequenz-floss/frequenz-repo-config-python/wiki/Configuring-a-new-GitHub-repository[0m
+[36mMake sure to (create and) configure your GitHub repository too: https://frequenz-floss.github.io/frequenz-repo-config-python/latest/user-guide/start-a-new-project/configure-github/[0m
 
 After completing it you can amend the previous commit using `git commit --amend` or create a new commit for the changes using `git commit`.
 

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 75.8.0",
   "setuptools_scm[toml] == 8.1.0",
-  "frequenz-repo-config[app] == 0.12.2",
+  "frequenz-repo-config[app] == 0.12.3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -59,7 +59,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.6.2",
   "mkdocstrings[python] == 0.28.0",
   "mkdocstrings-python == 1.14.6",
-  "frequenz-repo-config[app] == 0.12.2",
+  "frequenz-repo-config[app] == 0.12.3",
 ]
 dev-mypy = [
   "mypy == 1.9.0",
@@ -69,7 +69,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2024.10.9",
-  "frequenz-repo-config[app] == 0.12.2",
+  "frequenz-repo-config[app] == 0.12.3",
 ]
 dev-pylint = [
   # dev-pytest already defines a dependency to pylint because of the examples
@@ -79,7 +79,7 @@ dev-pylint = [
 dev-pytest = [
   "pytest == 8.3.4",
   "pylint == 3.3.4",       # We need this to check for the examples
-  "frequenz-repo-config[extra-lint-examples] == 0.12.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.12.3",
   "pytest-mock == 3.14.0",
   "pytest-asyncio == 0.25.3",
   "async-solipsism == 0.7",

--- a/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
@@ -29,7 +29,7 @@
 
 Here is a list of things that should be reviewed and FIXED:
 
-[36mMake sure to (create and) configure your GitHub repository too: https://github.com/frequenz-floss/frequenz-repo-config-python/wiki/Configuring-a-new-GitHub-repository[0m
+[36mMake sure to (create and) configure your GitHub repository too: https://frequenz-floss.github.io/frequenz-repo-config-python/latest/user-guide/start-a-new-project/configure-github/[0m
 
 After completing it you can amend the previous commit using `git commit --amend` or create a new commit for the changes using `git commit`.
 

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 75.8.0",
   "setuptools_scm[toml] == 8.1.0",
-  "frequenz-repo-config[lib] == 0.12.2",
+  "frequenz-repo-config[lib] == 0.12.3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -56,7 +56,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.6.2",
   "mkdocstrings[python] == 0.28.0",
   "mkdocstrings-python == 1.14.6",
-  "frequenz-repo-config[lib] == 0.12.2",
+  "frequenz-repo-config[lib] == 0.12.3",
 ]
 dev-mypy = [
   "mypy == 1.9.0",
@@ -66,7 +66,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2024.10.9",
-  "frequenz-repo-config[lib] == 0.12.2",
+  "frequenz-repo-config[lib] == 0.12.3",
 ]
 dev-pylint = [
   # dev-pytest already defines a dependency to pylint because of the examples
@@ -76,7 +76,7 @@ dev-pylint = [
 dev-pytest = [
   "pytest == 8.3.4",
   "pylint == 3.3.4",       # We need this to check for the examples
-  "frequenz-repo-config[extra-lint-examples] == 0.12.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.12.3",
   "pytest-mock == 3.14.0",
   "pytest-asyncio == 0.25.3",
   "async-solipsism == 0.7",

--- a/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
@@ -29,7 +29,7 @@
 
 Here is a list of things that should be reviewed and FIXED:
 
-[36mMake sure to (create and) configure your GitHub repository too: https://github.com/frequenz-floss/frequenz-repo-config-python/wiki/Configuring-a-new-GitHub-repository[0m
+[36mMake sure to (create and) configure your GitHub repository too: https://frequenz-floss.github.io/frequenz-repo-config-python/latest/user-guide/start-a-new-project/configure-github/[0m
 
 After completing it you can amend the previous commit using `git commit --amend` or create a new commit for the changes using `git commit`.
 

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 75.8.0",
   "setuptools_scm[toml] == 8.1.0",
-  "frequenz-repo-config[model] == 0.12.2",
+  "frequenz-repo-config[model] == 0.12.3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -60,7 +60,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.6.2",
   "mkdocstrings[python] == 0.28.0",
   "mkdocstrings-python == 1.14.6",
-  "frequenz-repo-config[model] == 0.12.2",
+  "frequenz-repo-config[model] == 0.12.3",
 ]
 dev-mypy = [
   "mypy == 1.9.0",
@@ -70,7 +70,7 @@ dev-mypy = [
 ]
 dev-noxfile = [
   "nox == 2024.10.9",
-  "frequenz-repo-config[model] == 0.12.2",
+  "frequenz-repo-config[model] == 0.12.3",
 ]
 dev-pylint = [
   # dev-pytest already defines a dependency to pylint because of the examples
@@ -80,7 +80,7 @@ dev-pylint = [
 dev-pytest = [
   "pytest == 8.3.4",
   "pylint == 3.3.4",       # We need this to check for the examples
-  "frequenz-repo-config[extra-lint-examples] == 0.12.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.12.3",
   "pytest-mock == 3.14.0",
   "pytest-asyncio == 0.25.3",
   "async-solipsism == 0.7",


### PR DESCRIPTION
Fixes #359

The link was pointing to a Wiki page that doesn't exist anymore.