### PR TITLE
Use new split workflow Ubuntu 24.04 in workflows

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -1,0 +1,55 @@
+name: Test PR
+
+on:
+  pull_request:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  nox:
+    name: Test with nox
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: "3.11"
+          nox-session: ci_checks_max
+
+  test-docs:
+    name: Test documentation website generation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   merge_group:
-  pull_request:
   push:
     # We need to explicitly include tags because otherwise when adding
     # `branches-ignore` it will only trigger on branches.
@@ -29,59 +28,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - amd64
+          - arm
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         python:
           - "3.11"
+          - "3.12"
         nox-session:
           # To speed things up a bit we use the special ci_checks_max session
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
 
     steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-
-      - name: Print environment (debug)
-        run: env
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[dev-noxfile]
-          pip freeze
-
-      - name: Create nox venv
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox --install-only -e "$NOX_SESSION"
-
-      - name: Print pip freeze for nox venv (debug)
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: |
-          . ".nox/$NOX_SESSION/bin/activate"
-          pip freeze
-          deactivate
-
-      - name: Run nox
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox -R -e "$NOX_SESSION"
-        timeout-minutes: 60
+          nox-session: ${{ matrix.nox-session }}
 
   # This job runs if all the `nox` matrix jobs ran and succeeded.
   # It is only used to have a single job that we can require in branch
@@ -93,158 +60,34 @@ jobs:
     needs: ["nox"]
     # We skip this job only if nox was also skipped
     if: always() && needs.nox.result != 'skipped'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DEPS_RESULT: ${{ needs.nox.result }}
     steps:
       - name: Check matrix job result
         run: test "$DEPS_RESULT" = "success"
 
-  nox-cross-arch:
-    name: Cross-arch tests with nox
-    if: github.event_name != 'pull_request'
-    strategy:
-      fail-fast: false
-      # Before adding new items to this matrix, make sure that a dockerfile
-      # exists for the combination of items in the matrix.
-      # Refer to .github/containers/nox-cross-arch/README.md to learn how to
-      # add and name new dockerfiles.
-      matrix:
-        arch:
-          - arm64
-        os:
-          - ubuntu-20.04
-        python:
-          - "3.11"
-        nox-session:
-          - "pytest_min"
-          - "pytest_max"
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/${{ matrix.arch }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # This is a workaround to prevent the cache from growing indefinitely.
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Cache container layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-nox-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}
-
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .github/containers/nox-cross-arch
-          file: .github/containers/nox-cross-arch/${{ matrix.arch }}-${{ matrix.os }}-python-${{ matrix.python }}.Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          tags: localhost/nox-cross-arch:latest
-          push: false
-          load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      # Refer to the workaround mentioned above
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      # Cache pip downloads
-      - name: Cache pip downloads
-        uses: actions/cache@v4
-        with:
-          path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
-
-      # This ensures that the docker container has access to the pip cache.
-      # Changing the user in the docker-run step causes it to fail due to
-      # incorrect permissions. Setting the ownership of the pip cache to root
-      # before running is a workaround to this issue.
-      - name: Set pip cache owners to root for docker
-        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R root:root /tmp/pip-cache; fi
-
-      - name: Run nox
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/${{ github.workspace }} \
-            -v /tmp/pip-cache:/root/.cache/pip \
-            -w ${{ github.workspace }} \
-            --net=host \
-            --platform linux/${{ matrix.arch }} \
-            localhost/nox-cross-arch:latest \
-            bash -c "pip install -e .[dev-noxfile]; \
-                     nox --install-only -e ${{ matrix.nox-session }}; \
-                     pip freeze; \
-                     nox -e ${{ matrix.nox-session }} -- -m 'not cookiecutter'"
-        timeout-minutes: 30
-
-      # This ensures that the runner has access to the pip cache.
-      - name: Reset pip cache ownership
-        if: always()
-        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R $USER:$USER /tmp/pip-cache; fi
-
-  # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
-  # As the `nox-all` job, its main purpose is to provide a single point of
-  # reference in branch protection rules, similar to how `nox-all` operates.
-  # However, there's a crucial difference: the `nox-cross-arch` job is omitted
-  # in PRs. Without the `nox-cross-arch-all` job, the inner matrix wouldn't be
-  # expanded in such scenarios. This would lead to the CI indefinitely waiting
-  # for these jobs to complete due to the branch protection rules, essentially
-  # causing it to hang. This behavior is tied to a recognized GitHub matrices
-  # issue when certain jobs are skipped. For a deeper understanding, refer to:
-  # https://github.com/orgs/community/discussions/9141
-  nox-cross-arch-all:
-    # The job name should match the name of the `nox-cross-arch` job.
-    name: Cross-arch tests with nox
-    needs: ["nox-cross-arch"]
-    # We skip this job only if nox-cross-arch was also skipped
-    if: always() && needs.nox-cross-arch.result != 'skipped'
-    runs-on: ubuntu-20.04
-    env:
-      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
-    steps:
-      - name: Check matrix job result
-        run: test "$DEPS_RESULT" = "success"
-
   build:
     name: Build distribution packages
-    runs-on: ubuntu-20.04
+    # Since this is a pure Python package, we only need to build it once. If it
+    # had any architecture specific code, we would need to build it for each
+    # architecture.
+    runs-on: ubuntu-24.04
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
 
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build
-          pip freeze
+          dependencies: build
 
       - name: Build the source and binary distribution
         run: python -m build
@@ -257,15 +100,27 @@ jobs:
           if-no-files-found: error
 
   test-installation:
-    name: Test package installation in different architectures
+    name: Test package installation
     needs: ["build"]
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
 
-      - name: Fetch sources
-        uses: actions/checkout@v4
+      - name: Print environment (debug)
+        run: env
 
       - name: Download package
         uses: actions/download-artifact@v4
@@ -273,50 +128,64 @@ jobs:
           name: dist-packages
           path: dist
 
-      - name: Make Git credentials available to docker
+      # This is necessary for the `pip` caching in the setup-python action to work
+      - name: Fetch the pyproject.toml file for this action hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
         run: |
-          touch ~/.git-credentials  # Ensure the file exists
-          cp ~/.git-credentials git-credentials || true
+          set -ux
+          gh api \
+              -X GET \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPO/contents/pyproject.toml?ref=$REF" \
+            > pyproject.toml
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up docker-buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test Installation
-        uses: docker/build-push-action@v6
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
-          context: .
-          file: .github/containers/test-installation/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: localhost/test-installation
-          push: false
+          python-version: ${{ matrix.python }}
+          dependencies: dist/*.whl
+
+      - name: Print installed packages (debug)
+        run: python -m pip freeze
+
+  # This job runs if all the `test-installation` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  test-installation-all:
+    # The job name should match the name of the `test-installation` job.
+    name: Test package installation
+    needs: ["test-installation"]
+    # We skip this job only if test-installation was also skipped
+    if: always() && needs.test-installation.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.test-installation.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
 
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Generate the documentation
         env:
@@ -334,31 +203,25 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    needs: ["nox-all", "nox-cross-arch-all", "test-installation"]
+    needs: ["nox-all", "test-installation-all"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
 
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Calculate and check version
         id: mike-version
@@ -413,7 +276,7 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
         uses: actions/download-artifact@v4
@@ -455,7 +318,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,12 @@
 
 ### Cookiecutter template
 
-All upgrading should be done via the migration script or regenerating the templates.
+* Branch protection rule **Protect version branches** was updated, please re-import it following the [instructions](https://frequenz-floss.github.io/frequenz-repo-config-python/v0.13/user-guide/start-a-new-project/configure-github/#rulesets).
+
+    > [!IMPORTANT]
+    > For **api** projects make sure to require the **Check proto files with protolint** status check too, which is not included by the provided ruleset by default.
+
+All other upgrading should be done via the migration script or regenerating the templates.
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/frequenz-floss/frequenz-repo-config-python/v0.12/cookiecutter/migrate.py | python3
@@ -18,7 +23,7 @@ curl -sSL https://raw.githubusercontent.com/frequenz-floss/frequenz-repo-config-
 
 But you might still need to adapt your code:
 
-<!-- Here upgrade steps for cookiecutter specifically -->
+* The new workflows will test using Python 3.12 too, if your code is not compatible with it, you might need to fix it, or you can just remove the Python 3.12 from the test matrix if you need a quick fix. For example, the `typing-extension` library is compatible with Python 3.12 from version 4.6.0, so you might need to upgrade it if you are using it.
 
 ## New Features
 
@@ -32,6 +37,18 @@ But you might still need to adapt your code:
     * We also group minor updates, as it works too for most libraries, typically except libraries that don't have a stable release yet (v0.x.x branch), so we make some exceptions for them.
     * Major updates and dependencies excluded by the above groups are still managed, but they'll create one PR per dependency, as breakage is expected, so it might need manual intervention.
     * Finally, we group some dependencies that are related to each other, and usually needs to be updated together.
+
+- The GitHub workflows is now split into PRs and CI workflows.
+
+    These new workflows also start using a new reusable `gh-action-nox`, native arm runners and Ubuntu 24.04, as [Ubuntu 20.04 will be removed from GitHub runners by April's 1st][ubuntu-20.04]. Python 3.12 is also added to the test matrix.
+
+    The PR action is more lightweight, and only tests with one matrix (the most widely used), so PRs can be tested more quickly.
+
+    The push workflow does a more intense testing with all matrix combinations. This also runs for the merge queue, so before PRs are actually merged the tests will run for the complete matrix.
+
+[ubuntu-20.04]: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/
+
+- The Python `Protect version branches` branch protection rule now request review to Copilot by default.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This release improves dependabot groups, so it is less likely that breaking updates are grouped with non-breaking updates and upgrades the GitHub workflows to use more actions, run PR checks faster and use Ubuntu 24.04 instead of 20.04.
 
 ## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ### Cookiecutter template
 
@@ -24,10 +22,10 @@ curl -sSL https://raw.githubusercontent.com/frequenz-floss/frequenz-repo-config-
 But you might still need to adapt your code:
 
 * The new workflows will test using Python 3.12 too, if your code is not compatible with it, you might need to fix it, or you can just remove the Python 3.12 from the test matrix if you need a quick fix. For example, the `typing-extension` library is compatible with Python 3.12 from version 4.6.0, so you might need to upgrade it if you are using it.
+* Check the new dependabot configuration file if you customized the dependabot configuration for the `pip` ecosystem.
+* Add exclusions for any other dependency you have at v0.x.x or that breaks frequently, so dependabot PRs are easy to merge.
 
 ## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ### Cookiecutter template
 
@@ -49,11 +47,3 @@ But you might still need to adapt your code:
 [ubuntu-20.04]: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/
 
 - The Python `Protect version branches` branch protection rule now request review to Copilot by default.
-
-## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
-
-### Cookiecutter template
-
-<!-- Here bug fixes for cookiecutter specifically -->

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -139,6 +139,12 @@ def regroup_dependabot() -> None:
         content=dependabot_content,
     )
 
+    manual_step(
+        "Please review the changes to the dependabot config if you made any "
+        "customizations. Also please check your dependencies and if you have other "
+        "dependencies at v0.x.x or that break often, add them to the exclusion list."
+    )
+
 
 def use_new_workflows() -> None:
     """Use the new GitHub Actions workflows."""

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -21,8 +21,10 @@ And remember to follow any manual instructions for each run.
 """  # noqa: E501
 
 import hashlib
+import json
 import os
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import SupportsIndex
@@ -34,8 +36,13 @@ def main() -> None:
     print("=" * 72)
     regroup_dependabot()
     print("=" * 72)
+    use_new_workflows()
+    print("=" * 72)
     print("Migration script finished. Remember to follow any manual instructions.")
     print("=" * 72)
+
+
+# pylint: disable=too-many-lines
 
 
 def regroup_dependabot() -> None:
@@ -131,6 +138,945 @@ def regroup_dependabot() -> None:
         count=1,
         content=dependabot_content,
     )
+
+
+def use_new_workflows() -> None:
+    """Use the new GitHub Actions workflows."""
+    print("Splitting the old GitHub ci.yaml workflow into ci.yaml and ci-pr.yaml...")
+    try:
+        os.unlink(".github/workflows/ci.yaml")
+    except OSError as err:
+        print(f"Failed to remove old ci.yaml: {err}", file=sys.stderr)
+
+    project_type: str | None = None
+    try:
+        with open(".cookiecutter-replay.json", "r", encoding="utf-8") as json_file:
+            cookiecutter_json = json.load(json_file)
+        project_type = cookiecutter_json["cookiecutter"]["type"]
+    except Exception as err:  # pylint: disable=broad-except
+        print(f"Failed to load .cookiecutter-replay.json: {err}", file=sys.stderr)
+        print("The project will be considered a regular project, not a API project")
+
+    def print_todos(file_name: str, contents: str) -> None:
+        for index, line in enumerate(contents.splitlines(), start=1):
+            if "TODO(cookiecutter):" in line:
+                print(f"  {file_name}:{index}: {line}")
+
+    with open(".github/workflows/ci.yaml", "w", encoding="utf-8") as new_file:
+        contents_ci = NEW_CI_API if project_type == "api" else NEW_CI
+        new_file.write(contents_ci)
+
+    with open(".github/workflows/ci-pr.yaml", "w", encoding="utf-8") as new_file:
+        contents_pr = NEW_CI_PR_API if project_type == "api" else NEW_CI_PR
+        new_file.write(contents_pr)
+
+    manual_step(
+        "The ci.yaml and ci-pr.yaml files have been created. Please review the "
+        "changes and make sure they work for your project and remember to add the new "
+        "ci-pr.yaml to git: git add .github/workflows/ci-pr.yaml. Please also check "
+        "the new TODOs."
+    )
+    print_todos(".github/workflows/ci.yaml", contents_ci)
+    print_todos(".github/workflows/ci-pr.yaml", contents_pr)
+
+
+NEW_CI = r"""name: CI
+
+on:
+  merge_group:
+  push:
+    # We need to explicitly include tags because otherwise when adding
+    # `branches-ignore` it will only trigger on branches.
+    tags:
+      - '*'
+    branches-ignore:
+      # Ignore pushes to merge queues.
+      # We only want to test the merge commit (`merge_group` event), the hashes
+      # in the push were already tested by the PR checks
+      - 'gh-readonly-queue/**'
+      - 'dependabot/**'
+  workflow_dispatch:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  nox:
+    name: Test with nox
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+        nox-session:
+          # To speed things up a bit we use the special ci_checks_max session
+          # that uses the same venv to run multiple linting sessions
+          - "ci_checks_max"
+          - "pytest_min"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: ${{ matrix.python }}
+          nox-session: ${{ matrix.nox-session }}
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  # This job runs if all the `nox` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  nox-all:
+    # The job name should match the name of the `nox` job.
+    name: Test with nox
+    needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
+
+  build:
+    name: Build distribution packages
+    # Since this is a pure Python package, we only need to build it once. If it
+    # had any architecture specific code, we would need to build it for each
+    # architecture.
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: build
+
+      - name: Build the source and binary distribution
+        run: python -m build
+
+      - name: Upload distribution files
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-packages
+          path: dist/
+          if-no-files-found: error
+
+  test-installation:
+    name: Test package installation
+    needs: ["build"]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Print environment (debug)
+        run: env
+
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-packages
+          path: dist
+
+      # This is necessary for the `pip` caching in the setup-python action to work
+      - name: Fetch the pyproject.toml file for this action hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
+        run: |
+          set -ux
+          gh api \
+              -X GET \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPO/contents/pyproject.toml?ref=$REF" \
+            > pyproject.toml
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ matrix.python }}
+          dependencies: dist/*.whl
+
+      - name: Print installed packages (debug)
+        run: python -m pip freeze
+
+  # This job runs if all the `test-installation` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  test-installation-all:
+    # The job name should match the name of the `test-installation` job.
+    name: Test package installation
+    needs: ["test-installation"]
+    # We skip this job only if test-installation was also skipped
+    if: always() && needs.test-installation.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.test-installation.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
+
+  test-docs:
+    name: Test documentation website generation
+    if: github.event_name != 'push'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error
+
+  publish-docs:
+    name: Publish documentation website to GitHub pages
+    needs: ["nox-all", "test-installation-all"]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Calculate and check version
+        id: mike-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          GIT_REF: ${{ github.ref }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          python -m frequenz.repo.config.cli.version.mike.info
+
+      - name: Fetch the gh-pages branch
+        if: steps.mike-version.outputs.version
+        run: git fetch origin gh-pages --depth=1
+
+      - name: Build site
+        if: steps.mike-version.outputs.version
+        env:
+          VERSION: ${{ steps.mike-version.outputs.version }}
+          TITLE: ${{ steps.mike-version.outputs.title }}
+          ALIASES: ${{ steps.mike-version.outputs.aliases }}
+          # This is not ideal, we need to define all these variables here
+          # because we need to calculate all the repository version information
+          # to be able to show the correct versions in the documentation when
+          # building it.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          GIT_REF: ${{ github.ref }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          mike deploy --update-aliases --title "$TITLE" "$VERSION" $ALIASES
+
+      - name: Sort site versions
+        if: steps.mike-version.outputs.version
+        run: |
+          git checkout gh-pages
+          python -m frequenz.repo.config.cli.version.mike.sort versions.json
+          git commit -a -m "Sort versions.json"
+
+      - name: Publish site
+        if: steps.mike-version.outputs.version
+        run: |
+          git push origin gh-pages
+
+  create-github-release:
+    name: Create GitHub release
+    needs: ["publish-docs"]
+    # Create a release only on tags creation
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      # We need write permissions on contents to create GitHub releases and on
+      # discussions to create the release announcement in the discussion forums
+      contents: write
+      discussions: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download distribution files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-packages
+          path: dist
+
+      - name: Download RELEASE_NOTES.md
+        run: |
+          set -ux
+          gh api \
+              -X GET \
+              -f ref=$REF \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPOSITORY/contents/RELEASE_NOTES.md" \
+            > RELEASE_NOTES.md
+        env:
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        run: |
+          set -ux
+          extra_opts=
+          if echo "$REF_NAME" | grep -- -; then extra_opts=" --prerelease"; fi
+          gh release create \
+            -R "$REPOSITORY" \
+            --notes-file RELEASE_NOTES.md \
+            --generate-notes \
+            $extra_opts \
+            $REF_NAME \
+            dist/*
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-to-pypi:
+    name: Publish packages to PyPI
+    needs: ["create-github-release"]
+    runs-on: ubuntu-24.04
+    permissions:
+      # For trusted publishing. See:
+      # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+      id-token: write
+    steps:
+      - name: Download distribution files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-packages
+          path: dist
+
+      - name: Publish the Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+"""
+
+NEW_CI_API = r"""name: CI
+
+on:
+  merge_group:
+  push:
+    # We need to explicitly include tags because otherwise when adding
+    # `branches-ignore` it will only trigger on branches.
+    tags:
+      - '*'
+    branches-ignore:
+      # Ignore pushes to merge queues.
+      # We only want to test the merge commit (`merge_group` event), the hashes
+      # in the push were already tested by the PR checks
+      - 'gh-readonly-queue/**'
+      - 'dependabot/**'
+  workflow_dispatch:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  protolint:
+    name: Check proto files with protolint
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Run protolint
+        # Only use hashes here, as we are passing the github token, we want to
+        # make sure updates are done consciously to avoid security issues if the
+        # action repo gets hacked
+        uses: yoheimuta/action-protolint@e94cc01b1ad085ed9427098442f66f2519c723eb # v1.0.0
+        with:
+          fail_on_error: true
+          filter_mode: nofilter
+          github_token: ${{ secrets.github_token }}
+          protolint_flags: proto/
+          protolint_version: "0.53.0"
+          reporter: github-check
+
+  nox:
+    name: Test with nox
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+        nox-session:
+          # To speed things up a bit we use the special ci_checks_max session
+          # that uses the same venv to run multiple linting sessions
+          - "ci_checks_max"
+          - "pytest_min"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: ${{ matrix.python }}
+          nox-session: ${{ matrix.nox-session }}
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  # This job runs if all the `nox` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  nox-all:
+    # The job name should match the name of the `nox` job.
+    name: Test with nox
+    needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
+
+  build:
+    name: Build distribution packages
+    # Since this is a pure Python package, we only need to build it once. If it
+    # had any architecture specific code, we would need to build it for each
+    # architecture.
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: build
+
+      - name: Build the source and binary distribution
+        run: python -m build
+
+      - name: Upload distribution files
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-packages
+          path: dist/
+          if-no-files-found: error
+
+  test-installation:
+    name: Test package installation
+    needs: ["build"]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Print environment (debug)
+        run: env
+
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-packages
+          path: dist
+
+      # This is necessary for the `pip` caching in the setup-python action to work
+      - name: Fetch the pyproject.toml file for this action hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
+        run: |
+          set -ux
+          gh api \
+              -X GET \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPO/contents/pyproject.toml?ref=$REF" \
+            > pyproject.toml
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ matrix.python }}
+          dependencies: dist/*.whl
+
+      - name: Print installed packages (debug)
+        run: python -m pip freeze
+
+  # This job runs if all the `test-installation` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  test-installation-all:
+    # The job name should match the name of the `test-installation` job.
+    name: Test package installation
+    needs: ["test-installation"]
+    # We skip this job only if test-installation was also skipped
+    if: always() && needs.test-installation.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.test-installation.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
+
+  test-docs:
+    name: Test documentation website generation
+    if: github.event_name != 'push'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error
+
+  publish-docs:
+    name: Publish documentation website to GitHub pages
+    needs: ["nox-all", "test-installation-all"]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Calculate and check version
+        id: mike-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          GIT_REF: ${{ github.ref }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          python -m frequenz.repo.config.cli.version.mike.info
+
+      - name: Fetch the gh-pages branch
+        if: steps.mike-version.outputs.version
+        run: git fetch origin gh-pages --depth=1
+
+      - name: Build site
+        if: steps.mike-version.outputs.version
+        env:
+          VERSION: ${{ steps.mike-version.outputs.version }}
+          TITLE: ${{ steps.mike-version.outputs.title }}
+          ALIASES: ${{ steps.mike-version.outputs.aliases }}
+          # This is not ideal, we need to define all these variables here
+          # because we need to calculate all the repository version information
+          # to be able to show the correct versions in the documentation when
+          # building it.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          GIT_REF: ${{ github.ref }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          mike deploy --update-aliases --title "$TITLE" "$VERSION" $ALIASES
+
+      - name: Sort site versions
+        if: steps.mike-version.outputs.version
+        run: |
+          git checkout gh-pages
+          python -m frequenz.repo.config.cli.version.mike.sort versions.json
+          git commit -a -m "Sort versions.json"
+
+      - name: Publish site
+        if: steps.mike-version.outputs.version
+        run: |
+          git push origin gh-pages
+
+  create-github-release:
+    name: Create GitHub release
+    needs: ["publish-docs"]
+    # Create a release only on tags creation
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      # We need write permissions on contents to create GitHub releases and on
+      # discussions to create the release announcement in the discussion forums
+      contents: write
+      discussions: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download distribution files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-packages
+          path: dist
+
+      - name: Download RELEASE_NOTES.md
+        run: |
+          set -ux
+          gh api \
+              -X GET \
+              -f ref=$REF \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPOSITORY/contents/RELEASE_NOTES.md" \
+            > RELEASE_NOTES.md
+        env:
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        run: |
+          set -ux
+          extra_opts=
+          if echo "$REF_NAME" | grep -- -; then extra_opts=" --prerelease"; fi
+          gh release create \
+            -R "$REPOSITORY" \
+            --notes-file RELEASE_NOTES.md \
+            --generate-notes \
+            $extra_opts \
+            $REF_NAME \
+            dist/*
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-to-pypi:
+    name: Publish packages to PyPI
+    needs: ["create-github-release"]
+    runs-on: ubuntu-24.04
+    permissions:
+      # For trusted publishing. See:
+      # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+      id-token: write
+    steps:
+      - name: Download distribution files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-packages
+          path: dist
+
+      - name: Publish the Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+"""
+
+NEW_CI_PR = r"""name: Test PR
+
+on:
+  pull_request:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  nox:
+    name: Test with nox
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: "3.11"
+          nox-session: ci_checks_max
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  test-docs:
+    name: Test documentation website generation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error
+"""
+
+NEW_CI_PR_API = r"""name: Test PR
+
+on:
+  pull_request:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  protolint:
+    name: Check proto files with protolint
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Run protolint
+        # Only use hashes here, as we are passing the github token, we want to
+        # make sure updates are done consciously to avoid security issues if the
+        # action repo gets hacked
+        uses: yoheimuta/action-protolint@e94cc01b1ad085ed9427098442f66f2519c723eb # v1.0.0
+        with:
+          fail_on_error: true
+          filter_mode: nofilter
+          github_token: ${{ secrets.github_token }}
+          protolint_flags: proto/
+          protolint_version: "0.53.0"
+          reporter: github-check
+
+  nox:
+    name: Test with nox
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: "3.11"
+          nox-session: ci_checks_max
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  test-docs:
+    name: Test documentation website generation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error
+"""
 
 
 def apply_patch(patch_content: str) -> None:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci-pr.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci-pr.yaml
@@ -1,0 +1,96 @@
+{% raw -%}
+name: Test PR
+
+on:
+  pull_request:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  {% endraw %}{% if cookiecutter.type == "api" %}{% raw -%}
+  protolint:
+    name: Check proto files with protolint
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Run protolint
+        # Only use hashes here, as we are passing the github token, we want to
+        # make sure updates are done consciously to avoid security issues if the
+        # action repo gets hacked
+        uses: yoheimuta/action-protolint@e94cc01b1ad085ed9427098442f66f2519c723eb # v1.0.0
+        with:
+          fail_on_error: true
+          filter_mode: nofilter
+          github_token: ${{ secrets.github_token }}
+          protolint_flags: proto/
+          protolint_version: "0.53.0"
+          reporter: github-check
+
+  {% endraw %}{% endif %}{% raw -%}
+  nox:
+    name: Test with nox
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: "3.11"
+          nox-session: ci_checks_max
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  test-docs:
+    name: Test documentation website generation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error
+{%- endraw %}

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ name: CI
 
 on:
   merge_group:
-  pull_request:
   push:
     # We need to explicitly include tags because otherwise when adding
     # `branches-ignore` it will only trigger on branches.
@@ -28,11 +27,11 @@ jobs:
   {% endraw %}{% if cookiecutter.type == "api" %}{% raw -%}
   protolint:
     name: Check proto files with protolint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -53,7 +52,7 @@ jobs:
           filter_mode: nofilter
           github_token: ${{ secrets.github_token }}
           protolint_flags: proto/
-          protolint_version: "0.45.0"
+          protolint_version: "0.53.0"
           reporter: github-check
 
   {% endraw %}{% endif %}{% raw -%}
@@ -62,63 +61,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - amd64
+          - arm
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         python:
           - "3.11"
+          - "3.12"
         nox-session:
           # To speed things up a bit we use the special ci_checks_max session
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
 
     steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Print environment (debug)
-        run: env
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[dev-noxfile]
-          pip freeze
-
-      - name: Create nox venv
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox --install-only -e "$NOX_SESSION"
-
-      - name: Print pip freeze for nox venv (debug)
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: |
-          . ".nox/$NOX_SESSION/bin/activate"
-          pip freeze
-          deactivate
-
-      - name: Run nox
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox -R -e "$NOX_SESSION"
-        timeout-minutes: 10
+          nox-session: ${{ matrix.nox-session }}
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
 
   # This job runs if all the `nox` matrix jobs ran and succeeded.
   # It is only used to have a single job that we can require in branch
@@ -130,144 +96,23 @@ jobs:
     needs: ["nox"]
     # We skip this job only if nox was also skipped
     if: always() && needs.nox.result != 'skipped'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DEPS_RESULT: ${{ needs.nox.result }}
     steps:
       - name: Check matrix job result
         run: test "$DEPS_RESULT" = "success"
 
-  nox-cross-arch:
-    name: Cross-arch tests with nox
-    if: github.event_name != 'pull_request'
-    strategy:
-      fail-fast: false
-      # Before adding new items to this matrix, make sure that a dockerfile
-      # exists for the combination of items in the matrix.
-      # Refer to .github/containers/nox-cross-arch/README.md to learn how to
-      # add and name new dockerfiles.
-      matrix:
-        arch:
-          - arm64
-        os:
-          - ubuntu-20.04
-        python:
-          - "3.11"
-        nox-session:
-          - "pytest_min"
-          - "pytest_max"
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/${{ matrix.arch }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # This is a workaround to prevent the cache from growing indefinitely.
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Cache container layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-nox-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}
-
-      - name: Build image
-        uses: docker/build-push-action@v5
-        with:
-          context: .github/containers/nox-cross-arch
-          file: .github/containers/nox-cross-arch/${{ matrix.arch }}-${{ matrix.os }}-python-${{ matrix.python }}.Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          tags: localhost/nox-cross-arch:latest
-          push: false
-          load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      # Refer to the workaround mentioned above
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      # Cache pip downloads
-      - name: Cache pip downloads
-        uses: actions/cache@v3
-        with:
-          path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
-
-      # This ensures that the docker container has access to the pip cache.
-      # Changing the user in the docker-run step causes it to fail due to
-      # incorrect permissions. Setting the ownership of the pip cache to root
-      # before running is a workaround to this issue.
-      - name: Set pip cache owners to root for docker
-        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R root:root /tmp/pip-cache; fi
-
-      - name: Run nox
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/${{ github.workspace }} \
-            -v /tmp/pip-cache:/root/.cache/pip \
-            -w ${{ github.workspace }} \
-            --net=host \
-            --platform linux/${{ matrix.arch }} \
-            localhost/nox-cross-arch:latest \
-            bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -e ${{ matrix.nox-session }}"
-        timeout-minutes: 30
-
-      # This ensures that the runner has access to the pip cache.
-      - name: Reset pip cache ownership
-        if: always()
-        run: sudo chown -R $USER:$USER /tmp/pip-cache
-
-  # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
-  # As the `nox-all` job, its main purpose is to provide a single point of
-  # reference in branch protection rules, similar to how `nox-all` operates.
-  # However, there's a crucial difference: the `nox-cross-arch` job is omitted
-  # in PRs. Without the `nox-cross-arch-all` job, the inner matrix wouldn't be
-  # expanded in such scenarios. This would lead to the CI indefinitely waiting
-  # for these jobs to complete due to the branch protection rules, essentially
-  # causing it to hang. This behavior is tied to a recognized GitHub matrices
-  # issue when certain jobs are skipped. For a deeper understanding, refer to:
-  # https://github.com/orgs/community/discussions/9141
-  nox-cross-arch-all:
-    # The job name should match the name of the `nox-cross-arch` job.
-    name: Cross-arch tests with nox
-    needs: ["nox-cross-arch"]
-    # We skip this job only if nox-cross-arch was also skipped
-    if: always() && needs.nox-cross-arch.result != 'skipped'
-    runs-on: ubuntu-20.04
-    env:
-      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
-    steps:
-      - name: Check matrix job result
-        run: test "$DEPS_RESULT" = "success"
-
   build:
     name: Build distribution packages
-    runs-on: ubuntu-20.04
+    # Since this is a pure Python package, we only need to build it once. If it
+    # had any architecture specific code, we would need to build it for each
+    # architecture.
+    runs-on: ubuntu-24.04
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -278,76 +123,102 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build
-          pip freeze
+          dependencies: build
 
       - name: Build the source and binary distribution
         run: python -m build
 
       - name: Upload distribution files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-packages
           path: dist/
           if-no-files-found: error
 
   test-installation:
-    name: Test package installation in different architectures
+    name: Test package installation
     needs: ["build"]
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
 
-      - name: Fetch sources
-        uses: actions/checkout@v4
+      - name: Print environment (debug)
+        run: env
 
       - name: Download package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
 
-      - name: Make Git credentials available to docker
+      # This is necessary for the `pip` caching in the setup-python action to work
+      - name: Fetch the pyproject.toml file for this action hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
         run: |
-          touch ~/.git-credentials  # Ensure the file exists
-          cp ~/.git-credentials git-credentials || true
+          set -ux
+          gh api \
+              -X GET \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPO/contents/pyproject.toml?ref=$REF" \
+            > pyproject.toml
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up docker-buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test Installation
-        uses: docker/build-push-action@v5
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
-          context: .
-          file: .github/containers/test-installation/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: localhost/test-installation
-          push: false
+          python-version: ${{ matrix.python }}
+          dependencies: dist/*.whl
+
+      - name: Print installed packages (debug)
+        run: python -m pip freeze
+
+  # This job runs if all the `test-installation` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  test-installation-all:
+    # The job name should match the name of the `test-installation` job.
+    name: Test package installation
+    needs: ["test-installation"]
+    # We skip this job only if test-installation was also skipped
+    if: always() && needs.test-installation.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.test-installation.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -358,17 +229,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Generate the documentation
         env:
@@ -378,7 +243,7 @@ jobs:
           mike set-default $MIKE_VERSION
 
       - name: Upload site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: site/
@@ -386,16 +251,14 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    {% endraw -%}
-    needs: ["nox-all", "nox-cross-arch-all", "test-installation"{{', "protolint"' if cookiecutter.type == "api"}}]
-    {% raw -%}
+    needs: ["nox-all", "test-installation-all"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -406,17 +269,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Calculate and check version
         id: mike-version
@@ -471,10 +328,10 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
@@ -513,14 +370,14 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
       id-token: write
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist

--- a/github-rulesets/python/Protect version branches.json
+++ b/github-rulesets/python/Protect version branches.json
@@ -39,6 +39,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
+        "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
             "context": "Test with nox",

--- a/github-rulesets/python/Protect version branches.json
+++ b/github-rulesets/python/Protect version branches.json
@@ -49,19 +49,7 @@
             "context": "DCO"
           },
           {
-            "context": "Build distribution packages",
-            "integration_id": 15368
-          },
-          {
             "context": "Test documentation website generation",
-            "integration_id": 15368
-          },
-          {
-            "context": "Test package installation in different architectures",
-            "integration_id": 15368
-          },
-          {
-            "context": "Cross-arch tests with nox",
             "integration_id": 15368
           },
           {

--- a/github-rulesets/python/Protect version branches.json
+++ b/github-rulesets/python/Protect version branches.json
@@ -27,7 +27,12 @@
         "require_last_push_approval": true,
         "dismiss_stale_reviews_on_push": true,
         "required_approving_review_count": 1,
-        "required_review_thread_resolution": false
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
       }
     },
     {

--- a/github-rulesets/python/Protect version branches.json
+++ b/github-rulesets/python/Protect version branches.json
@@ -28,6 +28,7 @@
         "dismiss_stale_reviews_on_push": true,
         "required_approving_review_count": 1,
         "required_review_thread_resolution": false,
+        "automatic_copilot_code_review_enabled": true,
         "allowed_merge_methods": [
           "merge",
           "squash",

--- a/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stdout.txt
@@ -2,8 +2,9 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci-pr.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci-pr.yaml
@@ -1,0 +1,62 @@
+name: Test PR
+
+on:
+  pull_request:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  nox:
+    name: Test with nox
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: "3.11"
+          nox-session: ci_checks_max
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  test-docs:
+    name: Test documentation website generation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   merge_group:
-  pull_request:
   push:
     # We need to explicitly include tags because otherwise when adding
     # `branches-ignore` it will only trigger on branches.
@@ -29,63 +28,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - amd64
+          - arm
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         python:
           - "3.11"
+          - "3.12"
         nox-session:
           # To speed things up a bit we use the special ci_checks_max session
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
 
     steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Print environment (debug)
-        run: env
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[dev-noxfile]
-          pip freeze
-
-      - name: Create nox venv
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox --install-only -e "$NOX_SESSION"
-
-      - name: Print pip freeze for nox venv (debug)
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: |
-          . ".nox/$NOX_SESSION/bin/activate"
-          pip freeze
-          deactivate
-
-      - name: Run nox
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox -R -e "$NOX_SESSION"
-        timeout-minutes: 10
+          nox-session: ${{ matrix.nox-session }}
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
 
   # This job runs if all the `nox` matrix jobs ran and succeeded.
   # It is only used to have a single job that we can require in branch
@@ -97,144 +63,23 @@ jobs:
     needs: ["nox"]
     # We skip this job only if nox was also skipped
     if: always() && needs.nox.result != 'skipped'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DEPS_RESULT: ${{ needs.nox.result }}
     steps:
       - name: Check matrix job result
         run: test "$DEPS_RESULT" = "success"
 
-  nox-cross-arch:
-    name: Cross-arch tests with nox
-    if: github.event_name != 'pull_request'
-    strategy:
-      fail-fast: false
-      # Before adding new items to this matrix, make sure that a dockerfile
-      # exists for the combination of items in the matrix.
-      # Refer to .github/containers/nox-cross-arch/README.md to learn how to
-      # add and name new dockerfiles.
-      matrix:
-        arch:
-          - arm64
-        os:
-          - ubuntu-20.04
-        python:
-          - "3.11"
-        nox-session:
-          - "pytest_min"
-          - "pytest_max"
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/${{ matrix.arch }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # This is a workaround to prevent the cache from growing indefinitely.
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Cache container layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-nox-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}
-
-      - name: Build image
-        uses: docker/build-push-action@v5
-        with:
-          context: .github/containers/nox-cross-arch
-          file: .github/containers/nox-cross-arch/${{ matrix.arch }}-${{ matrix.os }}-python-${{ matrix.python }}.Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          tags: localhost/nox-cross-arch:latest
-          push: false
-          load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      # Refer to the workaround mentioned above
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      # Cache pip downloads
-      - name: Cache pip downloads
-        uses: actions/cache@v3
-        with:
-          path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
-
-      # This ensures that the docker container has access to the pip cache.
-      # Changing the user in the docker-run step causes it to fail due to
-      # incorrect permissions. Setting the ownership of the pip cache to root
-      # before running is a workaround to this issue.
-      - name: Set pip cache owners to root for docker
-        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R root:root /tmp/pip-cache; fi
-
-      - name: Run nox
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/${{ github.workspace }} \
-            -v /tmp/pip-cache:/root/.cache/pip \
-            -w ${{ github.workspace }} \
-            --net=host \
-            --platform linux/${{ matrix.arch }} \
-            localhost/nox-cross-arch:latest \
-            bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -e ${{ matrix.nox-session }}"
-        timeout-minutes: 30
-
-      # This ensures that the runner has access to the pip cache.
-      - name: Reset pip cache ownership
-        if: always()
-        run: sudo chown -R $USER:$USER /tmp/pip-cache
-
-  # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
-  # As the `nox-all` job, its main purpose is to provide a single point of
-  # reference in branch protection rules, similar to how `nox-all` operates.
-  # However, there's a crucial difference: the `nox-cross-arch` job is omitted
-  # in PRs. Without the `nox-cross-arch-all` job, the inner matrix wouldn't be
-  # expanded in such scenarios. This would lead to the CI indefinitely waiting
-  # for these jobs to complete due to the branch protection rules, essentially
-  # causing it to hang. This behavior is tied to a recognized GitHub matrices
-  # issue when certain jobs are skipped. For a deeper understanding, refer to:
-  # https://github.com/orgs/community/discussions/9141
-  nox-cross-arch-all:
-    # The job name should match the name of the `nox-cross-arch` job.
-    name: Cross-arch tests with nox
-    needs: ["nox-cross-arch"]
-    # We skip this job only if nox-cross-arch was also skipped
-    if: always() && needs.nox-cross-arch.result != 'skipped'
-    runs-on: ubuntu-20.04
-    env:
-      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
-    steps:
-      - name: Check matrix job result
-        run: test "$DEPS_RESULT" = "success"
-
   build:
     name: Build distribution packages
-    runs-on: ubuntu-20.04
+    # Since this is a pure Python package, we only need to build it once. If it
+    # had any architecture specific code, we would need to build it for each
+    # architecture.
+    runs-on: ubuntu-24.04
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -245,76 +90,102 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build
-          pip freeze
+          dependencies: build
 
       - name: Build the source and binary distribution
         run: python -m build
 
       - name: Upload distribution files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-packages
           path: dist/
           if-no-files-found: error
 
   test-installation:
-    name: Test package installation in different architectures
+    name: Test package installation
     needs: ["build"]
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
 
-      - name: Fetch sources
-        uses: actions/checkout@v4
+      - name: Print environment (debug)
+        run: env
 
       - name: Download package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
 
-      - name: Make Git credentials available to docker
+      # This is necessary for the `pip` caching in the setup-python action to work
+      - name: Fetch the pyproject.toml file for this action hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
         run: |
-          touch ~/.git-credentials  # Ensure the file exists
-          cp ~/.git-credentials git-credentials || true
+          set -ux
+          gh api \
+              -X GET \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPO/contents/pyproject.toml?ref=$REF" \
+            > pyproject.toml
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up docker-buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test Installation
-        uses: docker/build-push-action@v5
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
-          context: .
-          file: .github/containers/test-installation/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: localhost/test-installation
-          push: false
+          python-version: ${{ matrix.python }}
+          dependencies: dist/*.whl
+
+      - name: Print installed packages (debug)
+        run: python -m pip freeze
+
+  # This job runs if all the `test-installation` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  test-installation-all:
+    # The job name should match the name of the `test-installation` job.
+    name: Test package installation
+    needs: ["test-installation"]
+    # We skip this job only if test-installation was also skipped
+    if: always() && needs.test-installation.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.test-installation.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -325,17 +196,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Generate the documentation
         env:
@@ -345,7 +210,7 @@ jobs:
           mike set-default $MIKE_VERSION
 
       - name: Upload site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: site/
@@ -353,14 +218,14 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    needs: ["nox-all", "nox-cross-arch-all", "test-installation"]
+    needs: ["nox-all", "test-installation-all"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -371,17 +236,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Calculate and check version
         id: mike-version
@@ -436,10 +295,10 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
@@ -478,14 +337,14 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
       id-token: write
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist

--- a/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stdout.txt
@@ -2,8 +2,10 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci-pr.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci-pr.yaml
@@ -1,0 +1,92 @@
+name: Test PR
+
+on:
+  pull_request:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  protolint:
+    name: Check proto files with protolint
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Run protolint
+        # Only use hashes here, as we are passing the github token, we want to
+        # make sure updates are done consciously to avoid security issues if the
+        # action repo gets hacked
+        uses: yoheimuta/action-protolint@e94cc01b1ad085ed9427098442f66f2519c723eb # v1.0.0
+        with:
+          fail_on_error: true
+          filter_mode: nofilter
+          github_token: ${{ secrets.github_token }}
+          protolint_flags: proto/
+          protolint_version: "0.53.0"
+          reporter: github-check
+
+  nox:
+    name: Test with nox
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: "3.11"
+          nox-session: ci_checks_max
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  test-docs:
+    name: Test documentation website generation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   merge_group:
-  pull_request:
   push:
     # We need to explicitly include tags because otherwise when adding
     # `branches-ignore` it will only trigger on branches.
@@ -26,11 +25,11 @@ env:
 jobs:
   protolint:
     name: Check proto files with protolint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -51,7 +50,7 @@ jobs:
           filter_mode: nofilter
           github_token: ${{ secrets.github_token }}
           protolint_flags: proto/
-          protolint_version: "0.45.0"
+          protolint_version: "0.53.0"
           reporter: github-check
 
   nox:
@@ -59,63 +58,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - amd64
+          - arm
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         python:
           - "3.11"
+          - "3.12"
         nox-session:
           # To speed things up a bit we use the special ci_checks_max session
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
 
     steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Print environment (debug)
-        run: env
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[dev-noxfile]
-          pip freeze
-
-      - name: Create nox venv
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox --install-only -e "$NOX_SESSION"
-
-      - name: Print pip freeze for nox venv (debug)
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: |
-          . ".nox/$NOX_SESSION/bin/activate"
-          pip freeze
-          deactivate
-
-      - name: Run nox
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox -R -e "$NOX_SESSION"
-        timeout-minutes: 10
+          nox-session: ${{ matrix.nox-session }}
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
 
   # This job runs if all the `nox` matrix jobs ran and succeeded.
   # It is only used to have a single job that we can require in branch
@@ -127,144 +93,23 @@ jobs:
     needs: ["nox"]
     # We skip this job only if nox was also skipped
     if: always() && needs.nox.result != 'skipped'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DEPS_RESULT: ${{ needs.nox.result }}
     steps:
       - name: Check matrix job result
         run: test "$DEPS_RESULT" = "success"
 
-  nox-cross-arch:
-    name: Cross-arch tests with nox
-    if: github.event_name != 'pull_request'
-    strategy:
-      fail-fast: false
-      # Before adding new items to this matrix, make sure that a dockerfile
-      # exists for the combination of items in the matrix.
-      # Refer to .github/containers/nox-cross-arch/README.md to learn how to
-      # add and name new dockerfiles.
-      matrix:
-        arch:
-          - arm64
-        os:
-          - ubuntu-20.04
-        python:
-          - "3.11"
-        nox-session:
-          - "pytest_min"
-          - "pytest_max"
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/${{ matrix.arch }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # This is a workaround to prevent the cache from growing indefinitely.
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Cache container layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-nox-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}
-
-      - name: Build image
-        uses: docker/build-push-action@v5
-        with:
-          context: .github/containers/nox-cross-arch
-          file: .github/containers/nox-cross-arch/${{ matrix.arch }}-${{ matrix.os }}-python-${{ matrix.python }}.Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          tags: localhost/nox-cross-arch:latest
-          push: false
-          load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      # Refer to the workaround mentioned above
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      # Cache pip downloads
-      - name: Cache pip downloads
-        uses: actions/cache@v3
-        with:
-          path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
-
-      # This ensures that the docker container has access to the pip cache.
-      # Changing the user in the docker-run step causes it to fail due to
-      # incorrect permissions. Setting the ownership of the pip cache to root
-      # before running is a workaround to this issue.
-      - name: Set pip cache owners to root for docker
-        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R root:root /tmp/pip-cache; fi
-
-      - name: Run nox
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/${{ github.workspace }} \
-            -v /tmp/pip-cache:/root/.cache/pip \
-            -w ${{ github.workspace }} \
-            --net=host \
-            --platform linux/${{ matrix.arch }} \
-            localhost/nox-cross-arch:latest \
-            bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -e ${{ matrix.nox-session }}"
-        timeout-minutes: 30
-
-      # This ensures that the runner has access to the pip cache.
-      - name: Reset pip cache ownership
-        if: always()
-        run: sudo chown -R $USER:$USER /tmp/pip-cache
-
-  # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
-  # As the `nox-all` job, its main purpose is to provide a single point of
-  # reference in branch protection rules, similar to how `nox-all` operates.
-  # However, there's a crucial difference: the `nox-cross-arch` job is omitted
-  # in PRs. Without the `nox-cross-arch-all` job, the inner matrix wouldn't be
-  # expanded in such scenarios. This would lead to the CI indefinitely waiting
-  # for these jobs to complete due to the branch protection rules, essentially
-  # causing it to hang. This behavior is tied to a recognized GitHub matrices
-  # issue when certain jobs are skipped. For a deeper understanding, refer to:
-  # https://github.com/orgs/community/discussions/9141
-  nox-cross-arch-all:
-    # The job name should match the name of the `nox-cross-arch` job.
-    name: Cross-arch tests with nox
-    needs: ["nox-cross-arch"]
-    # We skip this job only if nox-cross-arch was also skipped
-    if: always() && needs.nox-cross-arch.result != 'skipped'
-    runs-on: ubuntu-20.04
-    env:
-      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
-    steps:
-      - name: Check matrix job result
-        run: test "$DEPS_RESULT" = "success"
-
   build:
     name: Build distribution packages
-    runs-on: ubuntu-20.04
+    # Since this is a pure Python package, we only need to build it once. If it
+    # had any architecture specific code, we would need to build it for each
+    # architecture.
+    runs-on: ubuntu-24.04
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -275,76 +120,102 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build
-          pip freeze
+          dependencies: build
 
       - name: Build the source and binary distribution
         run: python -m build
 
       - name: Upload distribution files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-packages
           path: dist/
           if-no-files-found: error
 
   test-installation:
-    name: Test package installation in different architectures
+    name: Test package installation
     needs: ["build"]
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
 
-      - name: Fetch sources
-        uses: actions/checkout@v4
+      - name: Print environment (debug)
+        run: env
 
       - name: Download package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
 
-      - name: Make Git credentials available to docker
+      # This is necessary for the `pip` caching in the setup-python action to work
+      - name: Fetch the pyproject.toml file for this action hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
         run: |
-          touch ~/.git-credentials  # Ensure the file exists
-          cp ~/.git-credentials git-credentials || true
+          set -ux
+          gh api \
+              -X GET \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPO/contents/pyproject.toml?ref=$REF" \
+            > pyproject.toml
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up docker-buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test Installation
-        uses: docker/build-push-action@v5
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
-          context: .
-          file: .github/containers/test-installation/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: localhost/test-installation
-          push: false
+          python-version: ${{ matrix.python }}
+          dependencies: dist/*.whl
+
+      - name: Print installed packages (debug)
+        run: python -m pip freeze
+
+  # This job runs if all the `test-installation` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  test-installation-all:
+    # The job name should match the name of the `test-installation` job.
+    name: Test package installation
+    needs: ["test-installation"]
+    # We skip this job only if test-installation was also skipped
+    if: always() && needs.test-installation.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.test-installation.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -355,17 +226,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Generate the documentation
         env:
@@ -375,7 +240,7 @@ jobs:
           mike set-default $MIKE_VERSION
 
       - name: Upload site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: site/
@@ -383,14 +248,14 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    needs: ["nox-all", "nox-cross-arch-all", "test-installation", "protolint"]
+    needs: ["nox-all", "test-installation-all"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -401,17 +266,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Calculate and check version
         id: mike-version
@@ -466,10 +325,10 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
@@ -508,14 +367,14 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
       id-token: write
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist

--- a/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stdout.txt
@@ -2,8 +2,9 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci-pr.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci-pr.yaml
@@ -1,0 +1,62 @@
+name: Test PR
+
+on:
+  pull_request:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  nox:
+    name: Test with nox
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: "3.11"
+          nox-session: ci_checks_max
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  test-docs:
+    name: Test documentation website generation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   merge_group:
-  pull_request:
   push:
     # We need to explicitly include tags because otherwise when adding
     # `branches-ignore` it will only trigger on branches.
@@ -29,63 +28,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - amd64
+          - arm
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         python:
           - "3.11"
+          - "3.12"
         nox-session:
           # To speed things up a bit we use the special ci_checks_max session
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
 
     steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Print environment (debug)
-        run: env
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[dev-noxfile]
-          pip freeze
-
-      - name: Create nox venv
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox --install-only -e "$NOX_SESSION"
-
-      - name: Print pip freeze for nox venv (debug)
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: |
-          . ".nox/$NOX_SESSION/bin/activate"
-          pip freeze
-          deactivate
-
-      - name: Run nox
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox -R -e "$NOX_SESSION"
-        timeout-minutes: 10
+          nox-session: ${{ matrix.nox-session }}
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
 
   # This job runs if all the `nox` matrix jobs ran and succeeded.
   # It is only used to have a single job that we can require in branch
@@ -97,144 +63,23 @@ jobs:
     needs: ["nox"]
     # We skip this job only if nox was also skipped
     if: always() && needs.nox.result != 'skipped'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DEPS_RESULT: ${{ needs.nox.result }}
     steps:
       - name: Check matrix job result
         run: test "$DEPS_RESULT" = "success"
 
-  nox-cross-arch:
-    name: Cross-arch tests with nox
-    if: github.event_name != 'pull_request'
-    strategy:
-      fail-fast: false
-      # Before adding new items to this matrix, make sure that a dockerfile
-      # exists for the combination of items in the matrix.
-      # Refer to .github/containers/nox-cross-arch/README.md to learn how to
-      # add and name new dockerfiles.
-      matrix:
-        arch:
-          - arm64
-        os:
-          - ubuntu-20.04
-        python:
-          - "3.11"
-        nox-session:
-          - "pytest_min"
-          - "pytest_max"
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/${{ matrix.arch }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # This is a workaround to prevent the cache from growing indefinitely.
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Cache container layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-nox-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}
-
-      - name: Build image
-        uses: docker/build-push-action@v5
-        with:
-          context: .github/containers/nox-cross-arch
-          file: .github/containers/nox-cross-arch/${{ matrix.arch }}-${{ matrix.os }}-python-${{ matrix.python }}.Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          tags: localhost/nox-cross-arch:latest
-          push: false
-          load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      # Refer to the workaround mentioned above
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      # Cache pip downloads
-      - name: Cache pip downloads
-        uses: actions/cache@v3
-        with:
-          path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
-
-      # This ensures that the docker container has access to the pip cache.
-      # Changing the user in the docker-run step causes it to fail due to
-      # incorrect permissions. Setting the ownership of the pip cache to root
-      # before running is a workaround to this issue.
-      - name: Set pip cache owners to root for docker
-        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R root:root /tmp/pip-cache; fi
-
-      - name: Run nox
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/${{ github.workspace }} \
-            -v /tmp/pip-cache:/root/.cache/pip \
-            -w ${{ github.workspace }} \
-            --net=host \
-            --platform linux/${{ matrix.arch }} \
-            localhost/nox-cross-arch:latest \
-            bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -e ${{ matrix.nox-session }}"
-        timeout-minutes: 30
-
-      # This ensures that the runner has access to the pip cache.
-      - name: Reset pip cache ownership
-        if: always()
-        run: sudo chown -R $USER:$USER /tmp/pip-cache
-
-  # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
-  # As the `nox-all` job, its main purpose is to provide a single point of
-  # reference in branch protection rules, similar to how `nox-all` operates.
-  # However, there's a crucial difference: the `nox-cross-arch` job is omitted
-  # in PRs. Without the `nox-cross-arch-all` job, the inner matrix wouldn't be
-  # expanded in such scenarios. This would lead to the CI indefinitely waiting
-  # for these jobs to complete due to the branch protection rules, essentially
-  # causing it to hang. This behavior is tied to a recognized GitHub matrices
-  # issue when certain jobs are skipped. For a deeper understanding, refer to:
-  # https://github.com/orgs/community/discussions/9141
-  nox-cross-arch-all:
-    # The job name should match the name of the `nox-cross-arch` job.
-    name: Cross-arch tests with nox
-    needs: ["nox-cross-arch"]
-    # We skip this job only if nox-cross-arch was also skipped
-    if: always() && needs.nox-cross-arch.result != 'skipped'
-    runs-on: ubuntu-20.04
-    env:
-      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
-    steps:
-      - name: Check matrix job result
-        run: test "$DEPS_RESULT" = "success"
-
   build:
     name: Build distribution packages
-    runs-on: ubuntu-20.04
+    # Since this is a pure Python package, we only need to build it once. If it
+    # had any architecture specific code, we would need to build it for each
+    # architecture.
+    runs-on: ubuntu-24.04
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -245,76 +90,102 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build
-          pip freeze
+          dependencies: build
 
       - name: Build the source and binary distribution
         run: python -m build
 
       - name: Upload distribution files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-packages
           path: dist/
           if-no-files-found: error
 
   test-installation:
-    name: Test package installation in different architectures
+    name: Test package installation
     needs: ["build"]
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
 
-      - name: Fetch sources
-        uses: actions/checkout@v4
+      - name: Print environment (debug)
+        run: env
 
       - name: Download package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
 
-      - name: Make Git credentials available to docker
+      # This is necessary for the `pip` caching in the setup-python action to work
+      - name: Fetch the pyproject.toml file for this action hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
         run: |
-          touch ~/.git-credentials  # Ensure the file exists
-          cp ~/.git-credentials git-credentials || true
+          set -ux
+          gh api \
+              -X GET \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPO/contents/pyproject.toml?ref=$REF" \
+            > pyproject.toml
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up docker-buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test Installation
-        uses: docker/build-push-action@v5
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
-          context: .
-          file: .github/containers/test-installation/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: localhost/test-installation
-          push: false
+          python-version: ${{ matrix.python }}
+          dependencies: dist/*.whl
+
+      - name: Print installed packages (debug)
+        run: python -m pip freeze
+
+  # This job runs if all the `test-installation` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  test-installation-all:
+    # The job name should match the name of the `test-installation` job.
+    name: Test package installation
+    needs: ["test-installation"]
+    # We skip this job only if test-installation was also skipped
+    if: always() && needs.test-installation.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.test-installation.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -325,17 +196,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Generate the documentation
         env:
@@ -345,7 +210,7 @@ jobs:
           mike set-default $MIKE_VERSION
 
       - name: Upload site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: site/
@@ -353,14 +218,14 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    needs: ["nox-all", "nox-cross-arch-all", "test-installation"]
+    needs: ["nox-all", "test-installation-all"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -371,17 +236,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Calculate and check version
         id: mike-version
@@ -436,10 +295,10 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
@@ -478,14 +337,14 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
       id-token: write
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist

--- a/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stdout.txt
@@ -2,8 +2,9 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci-pr.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci-pr.yaml
@@ -1,0 +1,62 @@
+name: Test PR
+
+on:
+  pull_request:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  nox:
+    name: Test with nox
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: "3.11"
+          nox-session: ci_checks_max
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  test-docs:
+    name: Test documentation website generation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   merge_group:
-  pull_request:
   push:
     # We need to explicitly include tags because otherwise when adding
     # `branches-ignore` it will only trigger on branches.
@@ -29,63 +28,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - amd64
+          - arm
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         python:
           - "3.11"
+          - "3.12"
         nox-session:
           # To speed things up a bit we use the special ci_checks_max session
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
 
     steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Print environment (debug)
-        run: env
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[dev-noxfile]
-          pip freeze
-
-      - name: Create nox venv
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox --install-only -e "$NOX_SESSION"
-
-      - name: Print pip freeze for nox venv (debug)
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: |
-          . ".nox/$NOX_SESSION/bin/activate"
-          pip freeze
-          deactivate
-
-      - name: Run nox
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox -R -e "$NOX_SESSION"
-        timeout-minutes: 10
+          nox-session: ${{ matrix.nox-session }}
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
 
   # This job runs if all the `nox` matrix jobs ran and succeeded.
   # It is only used to have a single job that we can require in branch
@@ -97,144 +63,23 @@ jobs:
     needs: ["nox"]
     # We skip this job only if nox was also skipped
     if: always() && needs.nox.result != 'skipped'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DEPS_RESULT: ${{ needs.nox.result }}
     steps:
       - name: Check matrix job result
         run: test "$DEPS_RESULT" = "success"
 
-  nox-cross-arch:
-    name: Cross-arch tests with nox
-    if: github.event_name != 'pull_request'
-    strategy:
-      fail-fast: false
-      # Before adding new items to this matrix, make sure that a dockerfile
-      # exists for the combination of items in the matrix.
-      # Refer to .github/containers/nox-cross-arch/README.md to learn how to
-      # add and name new dockerfiles.
-      matrix:
-        arch:
-          - arm64
-        os:
-          - ubuntu-20.04
-        python:
-          - "3.11"
-        nox-session:
-          - "pytest_min"
-          - "pytest_max"
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/${{ matrix.arch }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # This is a workaround to prevent the cache from growing indefinitely.
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Cache container layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-nox-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}
-
-      - name: Build image
-        uses: docker/build-push-action@v5
-        with:
-          context: .github/containers/nox-cross-arch
-          file: .github/containers/nox-cross-arch/${{ matrix.arch }}-${{ matrix.os }}-python-${{ matrix.python }}.Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          tags: localhost/nox-cross-arch:latest
-          push: false
-          load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      # Refer to the workaround mentioned above
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      # Cache pip downloads
-      - name: Cache pip downloads
-        uses: actions/cache@v3
-        with:
-          path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
-
-      # This ensures that the docker container has access to the pip cache.
-      # Changing the user in the docker-run step causes it to fail due to
-      # incorrect permissions. Setting the ownership of the pip cache to root
-      # before running is a workaround to this issue.
-      - name: Set pip cache owners to root for docker
-        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R root:root /tmp/pip-cache; fi
-
-      - name: Run nox
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/${{ github.workspace }} \
-            -v /tmp/pip-cache:/root/.cache/pip \
-            -w ${{ github.workspace }} \
-            --net=host \
-            --platform linux/${{ matrix.arch }} \
-            localhost/nox-cross-arch:latest \
-            bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -e ${{ matrix.nox-session }}"
-        timeout-minutes: 30
-
-      # This ensures that the runner has access to the pip cache.
-      - name: Reset pip cache ownership
-        if: always()
-        run: sudo chown -R $USER:$USER /tmp/pip-cache
-
-  # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
-  # As the `nox-all` job, its main purpose is to provide a single point of
-  # reference in branch protection rules, similar to how `nox-all` operates.
-  # However, there's a crucial difference: the `nox-cross-arch` job is omitted
-  # in PRs. Without the `nox-cross-arch-all` job, the inner matrix wouldn't be
-  # expanded in such scenarios. This would lead to the CI indefinitely waiting
-  # for these jobs to complete due to the branch protection rules, essentially
-  # causing it to hang. This behavior is tied to a recognized GitHub matrices
-  # issue when certain jobs are skipped. For a deeper understanding, refer to:
-  # https://github.com/orgs/community/discussions/9141
-  nox-cross-arch-all:
-    # The job name should match the name of the `nox-cross-arch` job.
-    name: Cross-arch tests with nox
-    needs: ["nox-cross-arch"]
-    # We skip this job only if nox-cross-arch was also skipped
-    if: always() && needs.nox-cross-arch.result != 'skipped'
-    runs-on: ubuntu-20.04
-    env:
-      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
-    steps:
-      - name: Check matrix job result
-        run: test "$DEPS_RESULT" = "success"
-
   build:
     name: Build distribution packages
-    runs-on: ubuntu-20.04
+    # Since this is a pure Python package, we only need to build it once. If it
+    # had any architecture specific code, we would need to build it for each
+    # architecture.
+    runs-on: ubuntu-24.04
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -245,76 +90,102 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build
-          pip freeze
+          dependencies: build
 
       - name: Build the source and binary distribution
         run: python -m build
 
       - name: Upload distribution files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-packages
           path: dist/
           if-no-files-found: error
 
   test-installation:
-    name: Test package installation in different architectures
+    name: Test package installation
     needs: ["build"]
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
 
-      - name: Fetch sources
-        uses: actions/checkout@v4
+      - name: Print environment (debug)
+        run: env
 
       - name: Download package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
 
-      - name: Make Git credentials available to docker
+      # This is necessary for the `pip` caching in the setup-python action to work
+      - name: Fetch the pyproject.toml file for this action hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
         run: |
-          touch ~/.git-credentials  # Ensure the file exists
-          cp ~/.git-credentials git-credentials || true
+          set -ux
+          gh api \
+              -X GET \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPO/contents/pyproject.toml?ref=$REF" \
+            > pyproject.toml
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up docker-buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test Installation
-        uses: docker/build-push-action@v5
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
-          context: .
-          file: .github/containers/test-installation/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: localhost/test-installation
-          push: false
+          python-version: ${{ matrix.python }}
+          dependencies: dist/*.whl
+
+      - name: Print installed packages (debug)
+        run: python -m pip freeze
+
+  # This job runs if all the `test-installation` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  test-installation-all:
+    # The job name should match the name of the `test-installation` job.
+    name: Test package installation
+    needs: ["test-installation"]
+    # We skip this job only if test-installation was also skipped
+    if: always() && needs.test-installation.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.test-installation.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -325,17 +196,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Generate the documentation
         env:
@@ -345,7 +210,7 @@ jobs:
           mike set-default $MIKE_VERSION
 
       - name: Upload site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: site/
@@ -353,14 +218,14 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    needs: ["nox-all", "nox-cross-arch-all", "test-installation"]
+    needs: ["nox-all", "test-installation-all"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -371,17 +236,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Calculate and check version
         id: mike-version
@@ -436,10 +295,10 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
@@ -478,14 +337,14 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
       id-token: write
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist

--- a/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stdout.txt
@@ -2,8 +2,9 @@
 ./.github/ISSUE_TEMPLATE/config.yml:    # TODO(cookiecutter): Make sure the GitHub repository has a discussion category "Support"
 ./.github/keylabeler.yml:  # TODO(cookiecutter): Add other parts
 ./.github/labeler.yml:# TODO(cookiecutter): Add different parts of the source
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci-pr.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+./.github/workflows/ci.yaml:          # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies
 ./.github/workflows/ci.yaml:        # TODO(cookiecutter): Uncomment this for projects with private dependencies

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci-pr.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci-pr.yaml
@@ -1,0 +1,62 @@
+name: Test PR
+
+on:
+  pull_request:
+
+env:
+  # Please make sure this version is included in the `matrix`, as the
+  # `matrix` section can't use `env`, so it must be entered manually
+  DEFAULT_PYTHON_VERSION: '3.11'
+  # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
+  # but sadly `env` can't be used either in `runs-on`.
+
+jobs:
+  nox:
+    name: Test with nox
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
+        with:
+          python-version: "3.11"
+          nox-session: ci_checks_max
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
+
+  test-docs:
+    name: Test documentation website generation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+        # TODO(cookiecutter): Uncomment this for projects with private dependencies
+        # with:
+        #   username: ${{ secrets.GIT_USER }}
+        #   password: ${{ secrets.GIT_PASS }}
+
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   merge_group:
-  pull_request:
   push:
     # We need to explicitly include tags because otherwise when adding
     # `branches-ignore` it will only trigger on branches.
@@ -29,63 +28,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - amd64
+          - arm
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         python:
           - "3.11"
+          - "3.12"
         nox-session:
           # To speed things up a bit we use the special ci_checks_max session
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
 
     steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Print environment (debug)
-        run: env
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.0
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[dev-noxfile]
-          pip freeze
-
-      - name: Create nox venv
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox --install-only -e "$NOX_SESSION"
-
-      - name: Print pip freeze for nox venv (debug)
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: |
-          . ".nox/$NOX_SESSION/bin/activate"
-          pip freeze
-          deactivate
-
-      - name: Run nox
-        env:
-          NOX_SESSION: ${{ matrix.nox-session }}
-        run: nox -R -e "$NOX_SESSION"
-        timeout-minutes: 10
+          nox-session: ${{ matrix.nox-session }}
+          # TODO(cookiecutter): Uncomment this for projects with private dependencies
+          # git-username: ${{ secrets.GIT_USER }}
+          # git-password: ${{ secrets.GIT_PASS }}
 
   # This job runs if all the `nox` matrix jobs ran and succeeded.
   # It is only used to have a single job that we can require in branch
@@ -97,144 +63,23 @@ jobs:
     needs: ["nox"]
     # We skip this job only if nox was also skipped
     if: always() && needs.nox.result != 'skipped'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DEPS_RESULT: ${{ needs.nox.result }}
     steps:
       - name: Check matrix job result
         run: test "$DEPS_RESULT" = "success"
 
-  nox-cross-arch:
-    name: Cross-arch tests with nox
-    if: github.event_name != 'pull_request'
-    strategy:
-      fail-fast: false
-      # Before adding new items to this matrix, make sure that a dockerfile
-      # exists for the combination of items in the matrix.
-      # Refer to .github/containers/nox-cross-arch/README.md to learn how to
-      # add and name new dockerfiles.
-      matrix:
-        arch:
-          - arm64
-        os:
-          - ubuntu-20.04
-        python:
-          - "3.11"
-        nox-session:
-          - "pytest_min"
-          - "pytest_max"
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        # TODO(cookiecutter): Uncomment this for projects with private dependencies
-        # with:
-        #   username: ${{ secrets.GIT_USER }}
-        #   password: ${{ secrets.GIT_PASS }}
-
-      - name: Fetch sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/${{ matrix.arch }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # This is a workaround to prevent the cache from growing indefinitely.
-      # https://docs.docker.com/build/ci/github-actions/cache/#local-cache
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Cache container layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-nox-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}
-
-      - name: Build image
-        uses: docker/build-push-action@v5
-        with:
-          context: .github/containers/nox-cross-arch
-          file: .github/containers/nox-cross-arch/${{ matrix.arch }}-${{ matrix.os }}-python-${{ matrix.python }}.Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          tags: localhost/nox-cross-arch:latest
-          push: false
-          load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      # Refer to the workaround mentioned above
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      # Cache pip downloads
-      - name: Cache pip downloads
-        uses: actions/cache@v3
-        with:
-          path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
-
-      # This ensures that the docker container has access to the pip cache.
-      # Changing the user in the docker-run step causes it to fail due to
-      # incorrect permissions. Setting the ownership of the pip cache to root
-      # before running is a workaround to this issue.
-      - name: Set pip cache owners to root for docker
-        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R root:root /tmp/pip-cache; fi
-
-      - name: Run nox
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/${{ github.workspace }} \
-            -v /tmp/pip-cache:/root/.cache/pip \
-            -w ${{ github.workspace }} \
-            --net=host \
-            --platform linux/${{ matrix.arch }} \
-            localhost/nox-cross-arch:latest \
-            bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -e ${{ matrix.nox-session }}"
-        timeout-minutes: 30
-
-      # This ensures that the runner has access to the pip cache.
-      - name: Reset pip cache ownership
-        if: always()
-        run: sudo chown -R $USER:$USER /tmp/pip-cache
-
-  # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
-  # As the `nox-all` job, its main purpose is to provide a single point of
-  # reference in branch protection rules, similar to how `nox-all` operates.
-  # However, there's a crucial difference: the `nox-cross-arch` job is omitted
-  # in PRs. Without the `nox-cross-arch-all` job, the inner matrix wouldn't be
-  # expanded in such scenarios. This would lead to the CI indefinitely waiting
-  # for these jobs to complete due to the branch protection rules, essentially
-  # causing it to hang. This behavior is tied to a recognized GitHub matrices
-  # issue when certain jobs are skipped. For a deeper understanding, refer to:
-  # https://github.com/orgs/community/discussions/9141
-  nox-cross-arch-all:
-    # The job name should match the name of the `nox-cross-arch` job.
-    name: Cross-arch tests with nox
-    needs: ["nox-cross-arch"]
-    # We skip this job only if nox-cross-arch was also skipped
-    if: always() && needs.nox-cross-arch.result != 'skipped'
-    runs-on: ubuntu-20.04
-    env:
-      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
-    steps:
-      - name: Check matrix job result
-        run: test "$DEPS_RESULT" = "success"
-
   build:
     name: Build distribution packages
-    runs-on: ubuntu-20.04
+    # Since this is a pure Python package, we only need to build it once. If it
+    # had any architecture specific code, we would need to build it for each
+    # architecture.
+    runs-on: ubuntu-24.04
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -245,76 +90,102 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install required Python packages
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build
-          pip freeze
+          dependencies: build
 
       - name: Build the source and binary distribution
         run: python -m build
 
       - name: Upload distribution files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-packages
           path: dist/
           if-no-files-found: error
 
   test-installation:
-    name: Test package installation in different architectures
+    name: Test package installation
     needs: ["build"]
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm
+        os:
+          - ubuntu-24.04
+        python:
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
         #   password: ${{ secrets.GIT_PASS }}
 
-      - name: Fetch sources
-        uses: actions/checkout@v4
+      - name: Print environment (debug)
+        run: env
 
       - name: Download package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
 
-      - name: Make Git credentials available to docker
+      # This is necessary for the `pip` caching in the setup-python action to work
+      - name: Fetch the pyproject.toml file for this action hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
         run: |
-          touch ~/.git-credentials  # Ensure the file exists
-          cp ~/.git-credentials git-credentials || true
+          set -ux
+          gh api \
+              -X GET \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPO/contents/pyproject.toml?ref=$REF" \
+            > pyproject.toml
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up docker-buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test Installation
-        uses: docker/build-push-action@v5
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
-          context: .
-          file: .github/containers/test-installation/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: localhost/test-installation
-          push: false
+          python-version: ${{ matrix.python }}
+          dependencies: dist/*.whl
+
+      - name: Print installed packages (debug)
+        run: python -m pip freeze
+
+  # This job runs if all the `test-installation` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  test-installation-all:
+    # The job name should match the name of the `test-installation` job.
+    name: Test package installation
+    needs: ["test-installation"]
+    # We skip this job only if test-installation was also skipped
+    if: always() && needs.test-installation.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.test-installation.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -325,17 +196,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Generate the documentation
         env:
@@ -345,7 +210,7 @@ jobs:
           mike set-default $MIKE_VERSION
 
       - name: Upload site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: site/
@@ -353,14 +218,14 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    needs: ["nox-all", "nox-cross-arch-all", "test-installation"]
+    needs: ["nox-all", "test-installation-all"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - name: Setup Git
-        uses: frequenz-floss/gh-action-setup-git@v0.x.x
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
         # TODO(cookiecutter): Uncomment this for projects with private dependencies
         # with:
         #   username: ${{ secrets.GIT_USER }}
@@ -371,17 +236,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
-          pip freeze
+          dependencies: .[dev-mkdocs]
 
       - name: Calculate and check version
         id: mike-version
@@ -436,10 +295,10 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
@@ -478,14 +337,14 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
       id-token: write
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist


### PR DESCRIPTION
These new workflows also start using a new reusable `gh-action-nox`, native arm runners and Ubuntu 24.04, as [Ubuntu 20.04 will be removed from GitHub runners by April's 1st](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/
). Python 3.12 is also added to the test matrix.

The PR action is more lightweight, and only tests with one matrix (the most widely used), so PRs can be tested more quickly.

The push workflow does a more intense testing with all matrix combinations. This also runs for the merge queue, so before PRs are  actually merged the tests will run for the complete matrix.

Fixes #342, #341. Improves #59.