### PR TITLE
Fix setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ actor = []
 api = [
   "grpcio-tools >= 1.47.0, < 2",
   "mypy-protobuf >= 3.0.0, < 4",
-  "setuptools >= 67.6.0, < 76",
+  "setuptools >= 67.6.0, < 79",
 ]
 app = []
 lib = []
@@ -88,7 +88,7 @@ dev-mkdocs = [
 ]
 dev-mypy = [
   "mypy == 1.15.0",
-  "types-setuptools >= 67.6.0, < 79", # Should match the build dependency
+  "types-setuptools >= 67.6.0, < 79", # Should match the api dependency
   "types-Markdown == 3.7.0.20250322",
   "types-PyYAML == 6.0.12.20250326",
   "types-babel == 2.11.0.15",


### PR DESCRIPTION
It looks like the deependency got a bit mixed up at some point, and `types-setuptools` dependency started getting widenned and the real optional dependency (for `api`) stopped being widenned.

We'll probably need to keep an eye on dependabot to see if this was done by dependabot, but even if it is not, it is failing to widden the `setuptools` dependency for some reason.
