### PR TITLE
Use the new private ARM runner for private repositories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
@@ -41,7 +41,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Run nox
@@ -107,13 +107,13 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Setup Git

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,4 +35,4 @@ But you might still need to adapt your code:
 
 ### Cookiecutter template
 
-<!-- Here bug fixes for cookiecutter specifically -->
+- mkdocstrings: Move `paths` key to the right section in `mkdocs.yml`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@ But you might still need to adapt your code:
 ### Cookiecutter template
 
 - New warning ignores for protobuf gencode versions in pytest.
+- mkdocstrings: Updated the deprecated `import` config key to `inventories` in `mkdocs.yml`.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,3 +36,4 @@ But you might still need to adapt your code:
 ### Cookiecutter template
 
 - mkdocstrings: Move `paths` key to the right section in `mkdocs.yml`.
+- The CI workflow now uses the new private ARM runner for private repositories (and the public ARM runners for public repositories).

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -42,6 +42,9 @@ def main() -> None:
         "mkdocs.yml", "          import:", "          inventories:"
     )
     print("=" * 72)
+    print("Fixing wrongly located `paths` keys in mkdocs.yml...")
+    migrate_mkdocs_yaml(Path("mkdocs.yml"))
+    print("=" * 72)
     print("Migration script finished. Remember to follow any manual instructions.")
     print("=" * 72)
 
@@ -157,6 +160,65 @@ def migrate_filterwarnings(path: Path) -> None:
         f"No changes done to {path}. "
         "Please double check no manual steps are required."
     )
+
+
+def migrate_mkdocs_yaml(file_path: Path) -> None:
+    """Migrate the mkdocs.yml file to fix the `paths` key location."""
+    if not file_path.is_file():
+        manual_step(f"File {file_path} does not exist, skipping automatic migration.")
+        return
+
+    python_section = "        python:"
+    options_section = "          options:"
+    bad_paths_config = "            paths:"
+
+    lines = file_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    needs_migration = False
+    paths = ""
+    in_python = False
+    in_options = False
+
+    # 1) Detect whether there's a python_section followed by options_section
+    #    and then bad_paths_config in that block.
+    for line in lines:
+        if line.startswith(python_section):
+            in_python = True
+            in_options = False
+            continue
+        if in_python and line.startswith(options_section):
+            in_options = True
+            continue
+        if in_options and line.startswith(bad_paths_config):
+            needs_migration = True
+            paths = line[len(bad_paths_config) :].strip()
+            break
+        # If indentation drops back below python-level, stop looking in this block
+        if in_python and not line.startswith("        ") and not line.isspace():
+            in_python = False
+            in_options = False
+
+    if not needs_migration:
+        return
+
+    # 2) Perform the line-based rewrite:
+    new_lines: list[str] = []
+    inserted_paths = False
+
+    for line in lines:
+        # When we hit the python_section line, insert new paths config directly under it
+        if line.startswith(python_section) and not inserted_paths:
+            new_lines.append(line)
+            new_lines.append(f"          paths: {paths}\n")
+            inserted_paths = True
+            continue
+
+        # After inserting, drop the old "            paths:" line
+        if inserted_paths and line.startswith(bad_paths_config):
+            continue
+
+        new_lines.append(line)
+
+    file_path.write_text("".join(new_lines), encoding="utf-8")
 
 
 def apply_patch(patch_content: str) -> None:

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -34,6 +34,13 @@ def main() -> None:
     # Add a separation line like this one after each migration step.
     print("=" * 72)
     migrate_filterwarnings(Path("pyproject.toml"))
+    print(
+        "Renaming the deprecated mkdocstrings `import` to `inventories` in `mkdocs.yml`..."
+    )
+    print("=" * 72)
+    replace_file_contents_atomically(
+        "mkdocs.yml", "          import:", "          inventories:"
+    )
     print("=" * 72)
     print("Migration script finished. Remember to follow any manual instructions.")
     print("=" * 72)

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -45,6 +45,11 @@ def main() -> None:
     print("Fixing wrongly located `paths` keys in mkdocs.yml...")
     migrate_mkdocs_yaml(Path("mkdocs.yml"))
     print("=" * 72)
+    print("Migrating GitHub workflows to use the new arm64 runner...")
+    workflow_dir = Path(".github/workflows")
+    for workflow_file in [workflow_dir / "release.yaml", workflow_dir / "ci.yaml"]:
+        migrate_arm64_ci_yaml(workflow_file)
+    print("=" * 72)
     print("Migration script finished. Remember to follow any manual instructions.")
     print("=" * 72)
 
@@ -216,6 +221,40 @@ def migrate_mkdocs_yaml(file_path: Path) -> None:
         if inserted_paths and line.startswith(bad_paths_config):
             continue
 
+        new_lines.append(line)
+
+    file_path.write_text("".join(new_lines), encoding="utf-8")
+
+
+def migrate_arm64_ci_yaml(file_path: Path) -> None:
+    """Migrate the CI YAML file to use arm64 architecture."""
+    print(f"  - {file_path}")
+    if not file_path.is_file():
+        manual_step(f"File {file_path} does not exist, skipping automatic migration.")
+        return
+
+    lines = file_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    new_lines: list[str] = []
+
+    for line in lines:
+        # 1) Replace "- arm" with "- arm64" (preserve indentation)
+        if match := re.match(r"^(\s*)-\s*arm(64)?\s*$", line):
+            indent = match.group(1)
+            new_lines.append(f"{indent}- arm64\n")
+            continue
+
+        # 2) Update the runs-on line
+        if match := re.match(r"^(\s*)runs-on:\s*\$\{\{.*matrix\.arch.*\}\}\s*$", line):
+            indent = match.group(1)
+            new_line = (
+                f"{indent}runs-on: ${{{{ matrix.os }}}}"
+                f"${{{{ matrix.arch == 'arm64' && "
+                f"(github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}}}\n"
+            )
+            new_lines.append(new_line)
+            continue
+
+        # Otherwise, keep the line as-is
         new_lines.append(line)
 
     file_path.write_text("".join(new_lines), encoding="utf-8")

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
@@ -74,7 +74,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Run nox
@@ -147,13 +147,13 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Setup Git

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -103,8 +103,8 @@ plugins:
       default_handler: python
       handlers:
         python:
+          paths: ["{{cookiecutter | src_path}}"]
           options:
-            paths: ["{{cookiecutter | src_path}}"]
             docstring_section_style: spacy
             inherited_members: true
             merge_init_into_class: false

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/mkdocs.yml
@@ -116,7 +116,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
-          import:
+          inventories:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,8 +101,8 @@ plugins:
       default_handler: python
       handlers:
         python:
+          paths: ["src"]
           options:
-            paths: ["src"]
             docstring_section_style: spacy
             inherited_members: true
             merge_init_into_class: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
-          import:
+          inventories:
             - https://cookiecutter.readthedocs.io/en/stable/objects.inv
             - https://docs.python.org/3/objects.inv
             - https://mkdocstrings.github.io/objects.inv

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
@@ -41,7 +41,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Run nox
@@ -114,13 +114,13 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
@@ -103,8 +103,8 @@ plugins:
       default_handler: python
       handlers:
         python:
+          paths: ["src"]
           options:
-            paths: ["src"]
             docstring_section_style: spacy
             inherited_members: true
             merge_init_into_class: false

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/mkdocs.yml
@@ -116,7 +116,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
-          import:
+          inventories:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
@@ -71,7 +71,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Run nox
@@ -144,13 +144,13 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
@@ -103,8 +103,8 @@ plugins:
       default_handler: python
       handlers:
         python:
+          paths: ["py"]
           options:
-            paths: ["py"]
             docstring_section_style: spacy
             inherited_members: true
             merge_init_into_class: false

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/mkdocs.yml
@@ -116,7 +116,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
-          import:
+          inventories:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
@@ -41,7 +41,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Run nox
@@ -114,13 +114,13 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
@@ -103,8 +103,8 @@ plugins:
       default_handler: python
       handlers:
         python:
+          paths: ["src"]
           options:
-            paths: ["src"]
             docstring_section_style: spacy
             inherited_members: true
             merge_init_into_class: false

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/mkdocs.yml
@@ -116,7 +116,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
-          import:
+          inventories:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
@@ -41,7 +41,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Run nox
@@ -114,13 +114,13 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
@@ -103,8 +103,8 @@ plugins:
       default_handler: python
       handlers:
         python:
+          paths: ["src"]
           options:
-            paths: ["src"]
             docstring_section_style: spacy
             inherited_members: true
             merge_init_into_class: false

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/mkdocs.yml
@@ -116,7 +116,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
-          import:
+          inventories:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
@@ -41,7 +41,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Run nox
@@ -114,13 +114,13 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm
+          - arm64
         os:
           - ubuntu-24.04
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.os }}${{ matrix.arch == 'arm64' && (github.repository_visibility == 'private' && '-arm64' || '-arm') || '' }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
@@ -103,8 +103,8 @@ plugins:
       default_handler: python
       handlers:
         python:
+          paths: ["src"]
           options:
-            paths: ["src"]
             docstring_section_style: spacy
             inherited_members: true
             merge_init_into_class: false

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/mkdocs.yml
@@ -116,7 +116,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
-          import:
+          inventories:
             # TODO(cookiecutter): You might want to add other external references here
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv


### PR DESCRIPTION
We used to use the same name for our private ARM runner as the public one from GitHub, so we could easily re-use the same workflow for private and public repos. This doesn't work anymore because GitHub now randomly picks any runner with that name, and if it is a public one, then it will refuse to run for private repos. Because of this we now use the suffix `-arm64` for our private ARM runner, and we target the right runner based on the `github.repository_visibility` context variable.
