### PR TITLE
Fix missing comparison for equal versions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,6 +32,7 @@ But you might still need to adapt your code:
 
 - Fixed some typos in the docs.
 - Fixed wrong comparison for `mike` versions when versions were equal.
+- Fixed version regex escaping of `.`. This means that a version like v0x1e1 were accepted as valid semver versions. Now this version is not considered a semver version anymore.
 - `setuptools.grpc_tools`: Fix wrong passing of include paths when passed via:
 
     * Command-line: Now extra white-spaces and empty strings are removed, before they were passed to `protoc -I`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,33 +1,5 @@
 # Frequenz Repository Configuration Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-### Cookiecutter template
-
-All upgrading should be done via the migration script or regenerating the templates.
-
-```bash
-curl -sSL https://raw.githubusercontent.com/frequenz-floss/frequenz-repo-config-python/v0.12/cookiecutter/migrate.py | python3
-```
-
-But you might still need to adapt your code:
-
-<!-- Here upgrade steps for cookiecutter specifically -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-### Cookiecutter template
-
-<!-- Here new features for cookiecutter specifically -->
-
 ## Bug Fixes
 
 - Fixed some typos in the docs.
@@ -37,7 +9,3 @@ But you might still need to adapt your code:
 
     * Command-line: Now extra white-spaces and empty strings are removed, before they were passed to `protoc -I`.
     * `pyproject.toml`: Now an empty array/list can be passed to override the default paths, before this resulted in an empty string being passed to `protoc -I`.
-
-### Cookiecutter template
-
-<!-- Here bug fixes for cookiecutter specifically -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,7 @@ But you might still need to adapt your code:
 ## Bug Fixes
 
 - Fixed some typos in the docs.
+- Fixed wrong comparison for `mike` versions when versions were equal.
 - `setuptools.grpc_tools`: Fix wrong passing of include paths when passed via:
 
     * Command-line: Now extra white-spaces and empty strings are removed, before they were passed to `protoc -I`.

--- a/src/frequenz/repo/config/mkdocs/mike.py
+++ b/src/frequenz/repo/config/mkdocs/mike.py
@@ -207,6 +207,9 @@ def compare_mike_version(version1: str, version2: str) -> int:
     if is_version_v2:  # version1 is not a version
         return 1
 
+    if version1 == version2:
+        return 0
+
     return -1 if version1 < version2 else 1
 
 

--- a/src/frequenz/repo/config/mkdocs/mike.py
+++ b/src/frequenz/repo/config/mkdocs/mike.py
@@ -136,10 +136,10 @@ def build_mike_version(repo_info: RepoVersionInfo) -> MikeVersionInfo:
     )
 
 
-_is_version_re = re.compile(r"^v(\d+).(\d+)(-dev|-pre)?$")
-_stable_to_semver_re = re.compile(r"^v(\d+).(\d+)$")
-_pre_to_semver_re = re.compile(r"^v(\d+).(\d+)-pre$")
-_dev_to_semver_re = re.compile(r"^v(\d+).(\d+)-dev$")
+_is_version_re = re.compile(r"^v(\d+)\.(\d+)(?:-dev|-pre)?$")
+_stable_to_semver_re = re.compile(r"^v(\d+)\.(\d+)$")
+_pre_to_semver_re = re.compile(r"^v(\d+)\.(\d+)-pre$")
+_dev_to_semver_re = re.compile(r"^v(\d+)\.(\d+)-dev$")
 
 
 def _to_fake_sortable_semver(version: str) -> str:

--- a/tests/mkdocs/test_mike.py
+++ b/tests/mkdocs/test_mike.py
@@ -266,6 +266,7 @@ def test_build_mike_version(
         ("v2.0-pre", "v1.0-pre", 1),
         ("v2.0", "v1.0-pre", 1),
         ("blah", "v1.0-dev", 1),
+        ("blah", "blah", 0),
         ("alpha", "beta", -1),
     ],
 )

--- a/tests/mkdocs/test_mike.py
+++ b/tests/mkdocs/test_mike.py
@@ -267,6 +267,7 @@ def test_build_mike_version(
         ("v2.0", "v1.0-pre", 1),
         ("blah", "v1.0-dev", 1),
         ("blah", "blah", 0),
+        ("v1x0-dev", "v1.0-dev", 1),
         ("alpha", "beta", -1),
     ],
 )


### PR DESCRIPTION
- Fix wrong comparison for `mike` versions when versions were equal.
- Fix version regex escaping of `.`. This means that a version like v0x1e1 were accepted as valid semver versions. Now this version is not considered a semver version anymore.