### PR TITLE
template: Add flake8-datetimez

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,8 @@ But you might still need to adapt your code:
   - `dco-merge-queue.yml`: `DCO`
   - `labeler.yml`: `Label`
 
+- Added the [`flake8-datetimez`](https://github.com/pjknkda/flake8-datetimez) plugin to the `flake8` session. This plugin prevents accidental use of naive `datetime` objects by flagging calls that create or return datetimes without timezone information.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -43,6 +43,9 @@ def main() -> None:
     print("Migrating pyproject license metadata to SPDX format...")
     migrate_pyproject_license()
     print("=" * 72)
+    print("Adding flake8-datetimez plugin to dev-flake8 dependencies...")
+    migrate_add_flake8_datetimez()
+    print("=" * 72)
     print()
 
     if _manual_steps:
@@ -296,6 +299,40 @@ def migrate_pyproject_license() -> None:  # pylint: disable=too-many-branches
 
     replace_file_contents_atomically(pyproject_path, content, new_content, count=1)
     print("  Updated pyproject.toml: migrated license metadata")
+
+
+def migrate_add_flake8_datetimez() -> None:
+    """Add the flake8-datetimez plugin to dev-flake8 dependencies."""
+    pyproject_path = Path("pyproject.toml")
+    if not pyproject_path.exists():
+        print("  Skipping pyproject.toml (file not found)")
+        return
+
+    content = pyproject_path.read_text(encoding="utf-8")
+
+    if "flake8-datetimez" in content:
+        print("  Skipped pyproject.toml (flake8-datetimez already present)")
+        return
+
+    # Look for a pinned flake8 dependency line (e.g. "flake8 == 7.3.0") and
+    # insert flake8-datetimez right after it.
+    match = re.search(r'(  "flake8\s*==.*",?\n)', content)
+    if not match:
+        manual_step(
+            "Could not find a flake8 pin in pyproject.toml. "
+            'Please add `"flake8-datetimez == 20.10.0"` to the '
+            "`dev-flake8` optional dependencies."
+        )
+        return
+
+    flake8_line = match.group(1)
+    new_content = content.replace(
+        flake8_line,
+        flake8_line + '  "flake8-datetimez == 20.10.0",\n',
+        1,
+    )
+    replace_file_contents_atomically(pyproject_path, content, new_content, count=1)
+    print("  Updated pyproject.toml: added flake8-datetimez plugin")
 
 
 def read_project_type() -> str | None:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/pyproject.toml
@@ -87,6 +87,7 @@ email = "{{cookiecutter.author_email}}"
 [project.optional-dependencies]
 dev-flake8 = [
   "flake8 == 7.3.0",
+  "flake8-datetimez == 20.10.0",
   "flake8-docstrings == 1.7.0",
   "flake8-pyproject == 1.2.3",  # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.6.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ extra-lint-examples = [
 ]
 dev-flake8 = [
   "flake8 == 7.3.0",
+  "flake8-datetimez == 20.10.0",
   "flake8-docstrings == 1.7.0",
   "flake8-pyproject == 1.2.4", # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.8.3",

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/pyproject.toml
@@ -44,6 +44,7 @@ email = "floss@frequenz.com"
 [project.optional-dependencies]
 dev-flake8 = [
   "flake8 == 7.3.0",
+  "flake8-datetimez == 20.10.0",
   "flake8-docstrings == 1.7.0",
   "flake8-pyproject == 1.2.3",  # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.6.10",

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/pyproject.toml
@@ -55,6 +55,7 @@ email = "floss@frequenz.com"
 [project.optional-dependencies]
 dev-flake8 = [
   "flake8 == 7.3.0",
+  "flake8-datetimez == 20.10.0",
   "flake8-docstrings == 1.7.0",
   "flake8-pyproject == 1.2.3",  # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.6.10",

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/pyproject.toml
@@ -43,6 +43,7 @@ email = "floss@frequenz.com"
 [project.optional-dependencies]
 dev-flake8 = [
   "flake8 == 7.3.0",
+  "flake8-datetimez == 20.10.0",
   "flake8-docstrings == 1.7.0",
   "flake8-pyproject == 1.2.3",  # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.6.10",

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/pyproject.toml
@@ -40,6 +40,7 @@ email = "floss@frequenz.com"
 [project.optional-dependencies]
 dev-flake8 = [
   "flake8 == 7.3.0",
+  "flake8-datetimez == 20.10.0",
   "flake8-docstrings == 1.7.0",
   "flake8-pyproject == 1.2.3",  # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.6.10",

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/pyproject.toml
@@ -44,6 +44,7 @@ email = "floss@frequenz.com"
 [project.optional-dependencies]
 dev-flake8 = [
   "flake8 == 7.3.0",
+  "flake8-datetimez == 20.10.0",
   "flake8-docstrings == 1.7.0",
   "flake8-pyproject == 1.2.3",  # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.6.10",


### PR DESCRIPTION
The `flake8-datetimez` plugin is a Flake8 extension that makes sure no functions that create naive datetime objects (without a timezone) are not used.

Fixes #140.