### PR TITLE
Use GitHub app credentials for auto-dependabot

### DIFF
--- a/.github/cookiecutter-migrate.template.py
+++ b/.github/cookiecutter-migrate.template.py
@@ -85,6 +85,50 @@ def apply_patch(patch_content: str) -> None:
     subprocess.run(["patch", "-p1"], input=patch_content.encode(), check=True)
 
 
+def replace_file_atomically(  # noqa; DOC501, DOC503
+    filepath: str | Path, new_content: str
+) -> None:
+    """Replace a file atomically with the given content.
+
+    The replacement is done atomically by writing to a temporary file in the
+    same directory and then moving it to the target location.
+
+    Args:
+        filepath: The path to the file to replace.
+        new_content: The content to write to the file.
+    """
+    if isinstance(filepath, str):
+        filepath = Path(filepath)
+
+    tmp_dir = filepath.parent
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    # pylint: disable-next=consider-using-with
+    tmp = tempfile.NamedTemporaryFile(mode="w", dir=tmp_dir, delete=False)
+
+    try:
+        st = None
+        try:
+            st = os.stat(filepath)
+        except FileNotFoundError:
+            st = None
+
+        tmp.write(new_content)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+
+        if st is not None:
+            os.chmod(tmp.name, st.st_mode)
+
+        os.replace(tmp.name, filepath)
+
+    except BaseException:
+        tmp.close()
+        os.unlink(tmp.name)
+        raise
+
+
 def replace_file_contents_atomically(  # noqa; DOC501
     filepath: str | Path,
     old: str,
@@ -112,37 +156,7 @@ def replace_file_contents_atomically(  # noqa; DOC501
     if content is None:
         content = filepath.read_text(encoding="utf-8")
 
-    content = content.replace(old, new, count)
-
-    # Create temporary file in the same directory to ensure atomic move
-    tmp_dir = filepath.parent
-
-    # pylint: disable-next=consider-using-with
-    tmp = tempfile.NamedTemporaryFile(mode="w", dir=tmp_dir, delete=False)
-
-    try:
-        # Copy original file permissions
-        st = os.stat(filepath)
-
-        # Write the new content
-        tmp.write(content)
-
-        # Ensure all data is written to disk
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp.close()
-
-        # Copy original file permissions to the new file
-        os.chmod(tmp.name, st.st_mode)
-
-        # Perform atomic replace
-        os.rename(tmp.name, filepath)
-
-    except BaseException:
-        # Clean up the temporary file in case of errors
-        tmp.close()
-        os.unlink(tmp.name)
-        raise
+    replace_file_atomically(filepath, content.replace(old, new, count))
 
 
 def calculate_file_sha256_skip_lines(filepath: Path, skip_lines: int) -> str | None:

--- a/.github/cookiecutter-migrate.template.py
+++ b/.github/cookiecutter-migrate.template.py
@@ -139,6 +139,9 @@ def replace_file_contents_atomically(  # noqa; DOC501
 ) -> None:
     """Replace a file atomically with new content.
 
+    The replacement is done atomically by writing to a temporary file and
+    then moving it to the target location.
+
     Args:
         filepath: The path to the file to replace.
         old: The string to replace.
@@ -146,9 +149,6 @@ def replace_file_contents_atomically(  # noqa; DOC501
         count: The maximum number of occurrences to replace. If negative, all occurrences are
             replaced.
         content: The content to replace. If not provided, the file is read from disk.
-
-    The replacement is done atomically by writing to a temporary file and
-    then moving it to the target location.
     """
     if isinstance(filepath, str):
         filepath = Path(filepath)

--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,21 +1,37 @@
 name: Auto-merge Dependabot PR
 
 on:
-  pull_request:
+  # XXX: !!! SECURITY WARNING !!!
+  # pull_request_target has write access to the repo, and can read secrets. We
+  # need to audit any external actions executed in this workflow and make sure no
+  # checked out code is run (not even installing dependencies, as installing
+  # dependencies usually can execute pre/post-install scripts). We should also
+  # only use hashes to pick the action to execute (instead of tags or branches).
+  # For more details read:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
   auto-merge:
+    name: Auto-merge Dependabot PR
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-slim
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
+
       - name: Auto-merge Dependabot PR
         uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           dependency-type: 'all'
           auto-merge: 'true'
           merge-method: 'merge'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 This release migrates lightweight GitHub Actions workflow jobs to use the new cost-effective `ubuntu-slim` runner.
 It also updates cookiecutter pyproject license metadata to SPDX expressions to avoid setuptools deprecation warnings.
+The auto-dependabot workflow now uses a GitHub App installation token instead of `GITHUB_TOKEN` to fix merge queue and auto-merge failures.
 
 ## Upgrading
 
@@ -46,3 +47,10 @@ But you might still need to adapt your code:
 
 - Switched `project.license` to SPDX expressions and added `project.license-files`.
   This removes deprecated setuptools license metadata and avoids build warnings.
+
+- Fixed auto-dependabot workflow failing to trigger merge queue CI or complete
+  auto-merge. The workflow now uses a GitHub App installation token (via
+  `actions/create-github-app-token`) instead of `GITHUB_TOKEN`, which was
+  suppressing subsequent workflow runs by design. Workflow permissions have been
+  reduced to the minimum needed for the workflow (`contents: read` and
+  `pull-requests: write`).

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -46,6 +46,9 @@ def main() -> None:
     print("Adding flake8-datetimez plugin to dev-flake8 dependencies...")
     migrate_add_flake8_datetimez()
     print("=" * 72)
+    print("Migrating auto-dependabot workflow to use GitHub App token...")
+    migrate_auto_dependabot_token()
+    print("=" * 72)
     print()
 
     if _manual_steps:
@@ -121,21 +124,6 @@ def migrate_to_ubuntu_slim() -> None:
                 "old": '    needs: ["create-github-release"]\n    runs-on: ubuntu-24.04',
                 "new": '    needs: ["create-github-release"]\n    runs-on: ubuntu-slim',
             },
-        ],
-        "auto-dependabot.yaml": [
-            {
-                "job": "auto-merge",
-                "old": (
-                    "  auto-merge:\n"
-                    "    if: github.actor == 'dependabot[bot]'\n"
-                    "    runs-on: ubuntu-latest"
-                ),
-                "new": (
-                    "  auto-merge:\n"
-                    "    if: github.actor == 'dependabot[bot]'\n"
-                    "    runs-on: ubuntu-slim"
-                ),
-            }
         ],
         "release-notes-check.yml": [
             {
@@ -333,6 +321,85 @@ def migrate_add_flake8_datetimez() -> None:
     )
     replace_file_contents_atomically(pyproject_path, content, new_content, count=1)
     print("  Updated pyproject.toml: added flake8-datetimez plugin")
+
+
+def migrate_auto_dependabot_token() -> None:
+    """Migrate auto-dependabot workflow to use a GitHub App installation token.
+
+    This replaces the GITHUB_TOKEN with a GitHub App installation token to
+    ensure that auto-merge and merge queue events are properly triggered.
+    Using GITHUB_TOKEN suppresses subsequent workflow runs (by design), which
+    prevents merge queue CI from running and can cause auto-merge to silently
+    fail.
+
+    This migration intentionally overwrites `.github/workflows/auto-dependabot.yaml`
+    with the template version, as the workflow is small and user customizations
+    are not supported.
+    """
+    filepath = Path(".github") / "workflows" / "auto-dependabot.yaml"
+    # This is separated only to avoid flake8 errors about line length
+    dependabot_auto_approve_version = (
+        "3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2"
+    )
+    desired_content = (
+        r"""name: Auto-merge Dependabot PR
+
+on:
+  # XXX: !!! SECURITY WARNING !!!
+  # pull_request_target has write access to the repo, and can read secrets. We
+  # need to audit any external actions executed in this workflow and make sure no
+  # checked out code is run (not even installing dependencies, as installing
+  # dependencies usually can execute pre/post-install scripts). We should also
+  # only use hashes to pick the action to execute (instead of tags or branches).
+  # For more details read:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge Dependabot PR
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
+
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@"""
+        + dependabot_auto_approve_version
+        + r"""
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          dependency-type: 'all'
+          auto-merge: 'true'
+          merge-method: 'merge'
+          add-label: 'tool:auto-merged'
+"""
+    )
+
+    if filepath.exists():
+        content = filepath.read_text(encoding="utf-8").replace("\r\n", "\n")
+        if content == desired_content:
+            print(f"  Skipped {filepath}: already up to date")
+            return
+
+        print(
+            f"  Replacing {filepath} with updated workflow (overwriting any local changes)"
+        )
+        replace_file_atomically(filepath, desired_content)
+        return
+
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    replace_file_atomically(filepath, desired_content)
+    print(f"  Added {filepath}: installed updated workflow")
 
 
 def read_project_type() -> str | None:

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -457,6 +457,9 @@ def replace_file_contents_atomically(  # noqa; DOC501
 ) -> None:
     """Replace a file atomically with new content.
 
+    The replacement is done atomically by writing to a temporary file and
+    then moving it to the target location.
+
     Args:
         filepath: The path to the file to replace.
         old: The string to replace.
@@ -464,9 +467,6 @@ def replace_file_contents_atomically(  # noqa; DOC501
         count: The maximum number of occurrences to replace. If negative, all occurrences are
             replaced.
         content: The content to replace. If not provided, the file is read from disk.
-
-    The replacement is done atomically by writing to a temporary file and
-    then moving it to the target location.
     """
     if isinstance(filepath, str):
         filepath = Path(filepath)

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -403,6 +403,50 @@ def apply_patch(patch_content: str) -> None:
     subprocess.run(["patch", "-p1"], input=patch_content.encode(), check=True)
 
 
+def replace_file_atomically(  # noqa; DOC501, DOC503
+    filepath: str | Path, new_content: str
+) -> None:
+    """Replace a file atomically with the given content.
+
+    The replacement is done atomically by writing to a temporary file in the
+    same directory and then moving it to the target location.
+
+    Args:
+        filepath: The path to the file to replace.
+        new_content: The content to write to the file.
+    """
+    if isinstance(filepath, str):
+        filepath = Path(filepath)
+
+    tmp_dir = filepath.parent
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    # pylint: disable-next=consider-using-with
+    tmp = tempfile.NamedTemporaryFile(mode="w", dir=tmp_dir, delete=False)
+
+    try:
+        st = None
+        try:
+            st = os.stat(filepath)
+        except FileNotFoundError:
+            st = None
+
+        tmp.write(new_content)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+
+        if st is not None:
+            os.chmod(tmp.name, st.st_mode)
+
+        os.replace(tmp.name, filepath)
+
+    except BaseException:
+        tmp.close()
+        os.unlink(tmp.name)
+        raise
+
+
 def replace_file_contents_atomically(  # noqa; DOC501
     filepath: str | Path,
     old: str,
@@ -430,37 +474,7 @@ def replace_file_contents_atomically(  # noqa; DOC501
     if content is None:
         content = filepath.read_text(encoding="utf-8")
 
-    content = content.replace(old, new, count)
-
-    # Create temporary file in the same directory to ensure atomic move
-    tmp_dir = filepath.parent
-
-    # pylint: disable-next=consider-using-with
-    tmp = tempfile.NamedTemporaryFile(mode="w", dir=tmp_dir, delete=False)
-
-    try:
-        # Copy original file permissions
-        st = os.stat(filepath)
-
-        # Write the new content
-        tmp.write(content)
-
-        # Ensure all data is written to disk
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp.close()
-
-        # Copy original file permissions to the new file
-        os.chmod(tmp.name, st.st_mode)
-
-        # Perform atomic replace
-        os.rename(tmp.name, filepath)
-
-    except BaseException:
-        # Clean up the temporary file in case of errors
-        tmp.close()
-        os.unlink(tmp.name)
-        raise
+    replace_file_atomically(filepath, content.replace(old, new, count))
 
 
 def calculate_file_sha256_skip_lines(filepath: Path, skip_lines: int) -> str | None:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/auto-dependabot.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/auto-dependabot.yaml
@@ -1,23 +1,40 @@
-{% raw %}name: Auto-merge Dependabot PR
+{% raw -%}
+name: Auto-merge Dependabot PR
 
 on:
-  pull_request:
+  # XXX: !!! SECURITY WARNING !!!
+  # pull_request_target has write access to the repo, and can read secrets. We
+  # need to audit any external actions executed in this workflow and make sure no
+  # checked out code is run (not even installing dependencies, as installing
+  # dependencies usually can execute pre/post-install scripts). We should also
+  # only use hashes to pick the action to execute (instead of tags or branches).
+  # For more details read:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
   auto-merge:
+    name: Auto-merge Dependabot PR
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-slim
     steps:
-      - name: Auto-merge Dependabot PR
-        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
+
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@a115bc7e0194c08f876493f311ec6f4de53f984e # v1.4.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
           dependency-type: 'all'
           auto-merge: 'true'
           merge-method: 'merge'
           add-label: 'tool:auto-merged'
-{% endraw %}
+{%- endraw %}

--- a/docs/user-guide/start-a-new-project/configure-github.md
+++ b/docs/user-guide/start-a-new-project/configure-github.md
@@ -115,6 +115,25 @@ Import the following
 
 * Enable *Dependabot version updates* if relevant
 
+#### Auto-merge Dependabot PRs (GitHub App)
+
+The templates include an `.github/workflows/auto-dependabot.yaml` workflow that
+auto-approves and enables auto-merge for Dependabot PRs.
+
+This workflow uses a GitHub App installation token (not `GITHUB_TOKEN`). This is
+intentional: actions performed with `GITHUB_TOKEN` do not trigger certain
+follow-up workflow runs, which can prevent merge queue CI (`merge_group`) from
+starting.
+
+To make it work, ensure:
+
+* The GitHub App is installed on the repository.
+* The following secrets are available to the workflow (typically as org secrets):
+  `FREQUENZ_AUTO_DEPENDABOT_APP_ID` and `FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY`.
+* The app installation has sufficient repository permissions to approve/label
+  and enable auto-merge. In practice, this means at least `Pull requests: write`
+  and `Contents: write`.
+
 ## Code
 
 The basic code configuration should be generate using

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/auto-dependabot.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/auto-dependabot.yaml
@@ -1,23 +1,38 @@
 name: Auto-merge Dependabot PR
 
 on:
-  pull_request:
+  # XXX: !!! SECURITY WARNING !!!
+  # pull_request_target has write access to the repo, and can read secrets. We
+  # need to audit any external actions executed in this workflow and make sure no
+  # checked out code is run (not even installing dependencies, as installing
+  # dependencies usually can execute pre/post-install scripts). We should also
+  # only use hashes to pick the action to execute (instead of tags or branches).
+  # For more details read:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
   auto-merge:
+    name: Auto-merge Dependabot PR
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-slim
     steps:
-      - name: Auto-merge Dependabot PR
-        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
+
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@a115bc7e0194c08f876493f311ec6f4de53f984e # v1.4.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
           dependency-type: 'all'
           auto-merge: 'true'
           merge-method: 'merge'
           add-label: 'tool:auto-merged'
-

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/auto-dependabot.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/auto-dependabot.yaml
@@ -1,23 +1,38 @@
 name: Auto-merge Dependabot PR
 
 on:
-  pull_request:
+  # XXX: !!! SECURITY WARNING !!!
+  # pull_request_target has write access to the repo, and can read secrets. We
+  # need to audit any external actions executed in this workflow and make sure no
+  # checked out code is run (not even installing dependencies, as installing
+  # dependencies usually can execute pre/post-install scripts). We should also
+  # only use hashes to pick the action to execute (instead of tags or branches).
+  # For more details read:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
   auto-merge:
+    name: Auto-merge Dependabot PR
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-slim
     steps:
-      - name: Auto-merge Dependabot PR
-        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
+
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@a115bc7e0194c08f876493f311ec6f4de53f984e # v1.4.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
           dependency-type: 'all'
           auto-merge: 'true'
           merge-method: 'merge'
           add-label: 'tool:auto-merged'
-

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/auto-dependabot.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/auto-dependabot.yaml
@@ -1,23 +1,38 @@
 name: Auto-merge Dependabot PR
 
 on:
-  pull_request:
+  # XXX: !!! SECURITY WARNING !!!
+  # pull_request_target has write access to the repo, and can read secrets. We
+  # need to audit any external actions executed in this workflow and make sure no
+  # checked out code is run (not even installing dependencies, as installing
+  # dependencies usually can execute pre/post-install scripts). We should also
+  # only use hashes to pick the action to execute (instead of tags or branches).
+  # For more details read:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
   auto-merge:
+    name: Auto-merge Dependabot PR
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-slim
     steps:
-      - name: Auto-merge Dependabot PR
-        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
+
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@a115bc7e0194c08f876493f311ec6f4de53f984e # v1.4.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
           dependency-type: 'all'
           auto-merge: 'true'
           merge-method: 'merge'
           add-label: 'tool:auto-merged'
-

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/auto-dependabot.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/auto-dependabot.yaml
@@ -1,23 +1,38 @@
 name: Auto-merge Dependabot PR
 
 on:
-  pull_request:
+  # XXX: !!! SECURITY WARNING !!!
+  # pull_request_target has write access to the repo, and can read secrets. We
+  # need to audit any external actions executed in this workflow and make sure no
+  # checked out code is run (not even installing dependencies, as installing
+  # dependencies usually can execute pre/post-install scripts). We should also
+  # only use hashes to pick the action to execute (instead of tags or branches).
+  # For more details read:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
   auto-merge:
+    name: Auto-merge Dependabot PR
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-slim
     steps:
-      - name: Auto-merge Dependabot PR
-        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
+
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@a115bc7e0194c08f876493f311ec6f4de53f984e # v1.4.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
           dependency-type: 'all'
           auto-merge: 'true'
           merge-method: 'merge'
           add-label: 'tool:auto-merged'
-

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/auto-dependabot.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/auto-dependabot.yaml
@@ -1,23 +1,38 @@
 name: Auto-merge Dependabot PR
 
 on:
-  pull_request:
+  # XXX: !!! SECURITY WARNING !!!
+  # pull_request_target has write access to the repo, and can read secrets. We
+  # need to audit any external actions executed in this workflow and make sure no
+  # checked out code is run (not even installing dependencies, as installing
+  # dependencies usually can execute pre/post-install scripts). We should also
+  # only use hashes to pick the action to execute (instead of tags or branches).
+  # For more details read:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
   auto-merge:
+    name: Auto-merge Dependabot PR
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-slim
     steps:
-      - name: Auto-merge Dependabot PR
-        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
+
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@a115bc7e0194c08f876493f311ec6f4de53f984e # v1.4.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
           dependency-type: 'all'
           auto-merge: 'true'
           merge-method: 'merge'
           add-label: 'tool:auto-merged'
-


### PR DESCRIPTION
Actions performed with `GITHUB_TOKEN` may not trigger follow-up workflow runs, which can prevent merge queue CI (merge_group) from starting and can leave auto-merge “stuck” without merging. Using a GitHub App token avoids this suppression and restores reliable merge-queue processing.
