### PR TITLE
Fix dependabot-auto-approve version

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -29,7 +29,7 @@ jobs:
           private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
 
       - name: Auto-merge Dependabot PR
-        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
+        uses: frequenz-floss/dependabot-auto-approve@a115bc7e0194c08f876493f311ec6f4de53f984e # v1.4.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           dependency-type: 'all'

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -339,7 +339,7 @@ def migrate_auto_dependabot_token() -> None:
     filepath = Path(".github") / "workflows" / "auto-dependabot.yaml"
     # This is separated only to avoid flake8 errors about line length
     dependabot_auto_approve_version = (
-        "3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2"
+        "a115bc7e0194c08f876493f311ec6f4de53f984e # v1.4.0"
     )
     desired_content = (
         r"""name: Auto-merge Dependabot PR


### PR DESCRIPTION
The migration script was using an old version that didn't support the `pull_request_target` trigger event. We also regenerate the local auto-dependabot workflow.
