### PR TITLE
Simplify CI job matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,11 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
@@ -41,7 +39,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Run nox
@@ -105,15 +103,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Setup Git

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,8 @@ But you might still need to adapt your code:
 
 - Added the [`flake8-datetimez`](https://github.com/pjknkda/flake8-datetimez) plugin to the `flake8` session. This plugin prevents accidental use of naive `datetime` objects by flagging calls that create or return datetimes without timezone information.
 
+- The CI workflow now uses a simpler matrix.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -52,6 +52,9 @@ def main() -> None:
     print("Migrating auto-dependabot workflow to use GitHub App token...")
     migrate_auto_dependabot_token()
     print("=" * 72)
+    print("Migrating the CI workflows to use a platform matrix...")
+    migrate_platform_matrix()
+    print("=" * 72)
     print()
 
     if _manual_steps:
@@ -553,6 +556,55 @@ def replace_setuptools_pin(content: str, new_version: str) -> tuple[str, bool]:
         count=1,
     )
     return new_content, count > 0
+
+
+def migrate_platform_matrix() -> None:
+    """Migrate CI matrix from arch+os to a single platform entry.
+
+    This replaces the old matrix definition that used separate `arch` and `os`
+    entries with a single `platform` entry using GitHub's native arm64 runners
+    that are now available to both public and private repositories.
+    """
+    workflow_file = Path(".github/workflows/ci.yaml")
+    print(f"  - {workflow_file}")
+    if not workflow_file.is_file():
+        manual_step(
+            f"Could not find {workflow_file}; please manually migrate to use a"
+            "please manually migrate to use a `platform` matrix entry."
+        )
+        return
+
+    content = workflow_file.read_text(encoding="utf-8")
+    new_content = content
+
+    # Replace the arch+os matrix block with platform.
+    # Handle both "arm" (old) and "arm64" (intermediate) variants.
+    new_content = re.sub(
+        r"( +)arch:\n\1  - amd64\n\1  - arm(?:64)?\n\1os:\n\1  - ubuntu-24\.04\n",
+        r"\g<1>platform:\n\g<1>  - ubuntu-24.04\n\g<1>  - ubuntu-24.04-arm\n",
+        new_content,
+    )
+
+    # Replace any runs-on expression referencing matrix.arch with the simpler
+    # matrix.platform reference.
+    new_content = re.sub(
+        r"runs-on: \$\{\{.*matrix\.arch.*\}\}",
+        "runs-on: ${{ matrix.platform }}",
+        new_content,
+    )
+
+    if new_content == content:
+        if "matrix.platform" in content:
+            print("    Already uses platform matrix")
+        else:
+            manual_step(
+                f"Could not find arch+os matrix pattern in {workflow_file}; "
+                "please manually migrate to use a `platform` matrix entry."
+            )
+        return
+
+    replace_file_contents_atomically(workflow_file, content, new_content, count=1)
+    print("    Migrated arch+os matrix to platform")
 
 
 def apply_patch(patch_content: str) -> None:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -61,11 +61,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
@@ -74,7 +72,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Run nox
@@ -145,15 +143,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -28,11 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
@@ -41,7 +39,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Run nox
@@ -112,15 +110,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -58,11 +58,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
@@ -71,7 +69,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Run nox
@@ -142,15 +140,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -28,11 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
@@ -41,7 +39,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Run nox
@@ -112,15 +110,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -28,11 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
@@ -41,7 +39,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Run nox
@@ -112,15 +110,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Setup Git

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -28,11 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
@@ -41,7 +39,7 @@ jobs:
           # that uses the same venv to run multiple linting sessions
           - "ci_checks_max"
           - "pytest_min"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Run nox
@@ -112,15 +110,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm
-        os:
+        platform:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python:
           - "3.11"
           - "3.12"
-    runs-on: ${{ matrix.os }}${{ matrix.arch != 'amd64' && format('-{0}', matrix.arch) || '' }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Setup Git


### PR DESCRIPTION
We are currently not using the distinction between "os" and "arch", and only using both to construct the `runs-on:` string. This makes things much more complicated than necessary, so this commit updates the matrix to use a single 'platform' key that we can use directly in `runs-on`.
