### PR TITLE
Fix dependabot repo-config and mkdocstrings groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,11 +38,13 @@ updates:
           - "mkdocs-gen-files"
           - "mkdocs-literate-nav"
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
           - "pydoclint"
           - "pytest-asyncio"
       mkdocstrings:
         patterns:
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,3 +48,5 @@ But you might still need to adapt your code:
 - Switched `project.license` to SPDX expressions and added `project.license-files`. This removes deprecated setuptools license metadata and avoids build warnings.
 
 - Fixed auto-dependabot workflow failing to trigger merge queue CI or complete auto-merge. The workflow now uses a GitHub App installation token (via `actions/create-github-app-token`) instead of `GITHUB_TOKEN`, which was suppressing subsequent workflow runs by design. Workflow permissions have been reduced to the minimum needed for the workflow (`contents: read` and `pull-requests: write`).
+
+- Fix dependabot group patterns for repo-config and mkdocstrings.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -45,12 +45,6 @@ But you might still need to adapt your code:
 
 ### Cookiecutter template
 
-- Switched `project.license` to SPDX expressions and added `project.license-files`.
-  This removes deprecated setuptools license metadata and avoids build warnings.
+- Switched `project.license` to SPDX expressions and added `project.license-files`. This removes deprecated setuptools license metadata and avoids build warnings.
 
-- Fixed auto-dependabot workflow failing to trigger merge queue CI or complete
-  auto-merge. The workflow now uses a GitHub App installation token (via
-  `actions/create-github-app-token`) instead of `GITHUB_TOKEN`, which was
-  suppressing subsequent workflow runs by design. Workflow permissions have been
-  reduced to the minimum needed for the workflow (`contents: read` and
-  `pull-requests: write`).
+- Fixed auto-dependabot workflow failing to trigger merge queue CI or complete auto-merge. The workflow now uses a GitHub App installation token (via `actions/create-github-app-token`) instead of `GITHUB_TOKEN`, which was suppressing subsequent workflow runs by design. Workflow permissions have been reduced to the minimum needed for the workflow (`contents: read` and `pull-requests: write`).

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -46,6 +46,9 @@ def main() -> None:
     print("Adding flake8-datetimez plugin to dev-flake8 dependencies...")
     migrate_add_flake8_datetimez()
     print("=" * 72)
+    print("Fixing dependabot repo-config and mkdocstrings patterns...")
+    migrate_dependabot_patterns()
+    print("=" * 72)
     print("Migrating auto-dependabot workflow to use GitHub App token...")
     migrate_auto_dependabot_token()
     print("=" * 72)
@@ -321,6 +324,93 @@ def migrate_add_flake8_datetimez() -> None:
     )
     replace_file_contents_atomically(pyproject_path, content, new_content, count=1)
     print("  Updated pyproject.toml: added flake8-datetimez plugin")
+
+
+def migrate_dependabot_patterns() -> None:
+    """Fix dependabot repo-config and mkdocstrings dependency patterns.
+
+    Dependabot wildcards don't work when ``[]`` is involved in optional
+    dependency specifiers, so we need to list them explicitly in the
+    include/exclude patterns.
+
+    This replaces ``frequenz-repo-config*`` with explicit entries for the
+    base package, the project-type extra, and the ``extra-lint-examples``
+    extra, and adds ``mkdocstrings[python]`` alongside ``mkdocstrings*``.
+    """
+    filepath = Path(".github") / "dependabot.yml"
+    if not filepath.exists():
+        manual_step(
+            f"Unable to find {filepath}. Please update your dependabot config "
+            "manually by replacing any `frequenz-repo-config*` patterns with explicit "
+            "entries for `frequenz-repo-config`, `frequenz-repo-config[<your-type>]`, and "
+            "`frequenz-repo-config[extra-lint-examples]`, and add `mkdocstrings[python]` "
+            "to the patterns for the `mkdocstrings` group if it is missing."
+        )
+        return
+
+    content = filepath.read_text(encoding="utf-8")
+    new_content = content
+    updated = False
+
+    project_type = read_project_type()
+    if project_type is None:
+        manual_step(
+            "Unable to detect the cookiecutter project type from "
+            ".cookiecutter-replay.json; cannot determine the correct "
+            "frequenz-repo-config optional dependency for dependabot.yml. "
+            "Please replace any `frequenz-repo-config*` patterns with explicit "
+            "entries for `frequenz-repo-config`, "
+            "`frequenz-repo-config[<your-type>]`, and "
+            "`frequenz-repo-config[extra-lint-examples]`."
+        )
+        return
+
+    # Replace frequenz-repo-config* with explicit entries (appears in both
+    # exclude-patterns and repo-config group patterns).
+    old_repo_config = '          - "frequenz-repo-config*"\n'
+    new_repo_config = (
+        '          - "frequenz-repo-config"\n'
+        f'          - "frequenz-repo-config[{project_type}]"\n'
+        '          - "frequenz-repo-config[extra-lint-examples]"\n'
+    )
+    if old_repo_config in new_content:
+        new_content = new_content.replace(old_repo_config, new_repo_config)
+        updated = True
+    elif f'"frequenz-repo-config[{project_type}]"' in new_content:
+        print(f"  Skipped {filepath}: repo-config patterns already updated")
+    else:
+        manual_step(
+            f"Could not find `frequenz-repo-config*` pattern in {filepath}. "
+            "Please replace it with explicit entries for "
+            "`frequenz-repo-config`, "
+            f"`frequenz-repo-config[{project_type}]`, and "
+            "`frequenz-repo-config[extra-lint-examples]`."
+        )
+
+    # Add mkdocstrings[python] after mkdocstrings* (appears in both
+    # exclude-patterns and mkdocstrings group patterns).
+    old_mkdocstrings = '          - "mkdocstrings*"\n'
+    new_mkdocstrings = (
+        '          - "mkdocstrings*"\n          - "mkdocstrings[python]"\n'
+    )
+    if old_mkdocstrings in new_content and '"mkdocstrings[python]"' not in new_content:
+        new_content = new_content.replace(old_mkdocstrings, new_mkdocstrings)
+        updated = True
+    elif '"mkdocstrings[python]"' in new_content:
+        print(f"  Skipped {filepath}: mkdocstrings patterns already updated")
+    else:
+        manual_step(
+            f"Could not find `mkdocstrings*` pattern in {filepath}. "
+            'Please add `"mkdocstrings[python]"` alongside `"mkdocstrings*"` '
+            "in both the exclude-patterns and the mkdocstrings group."
+        )
+
+    if not updated or new_content == content:
+        print(f"  Skipped {filepath} (already up to date)")
+        return
+
+    replace_file_contents_atomically(filepath, content, new_content, count=1)
+    print(f"  Updated {filepath}: fixed repo-config and mkdocstrings patterns")
 
 
 def migrate_auto_dependabot_token() -> None:

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/dependabot.yml
@@ -37,11 +37,14 @@ updates:
 {%- if cookiecutter.type == "api" %}
           - "frequenz-api-common"
 {%- endif %}
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[{{ cookiecutter.type }}]"
+          - "frequenz-repo-config[extra-lint-examples]"
           - "markdown-callouts"
           - "mkdocs-gen-files"
           - "mkdocs-literate-nav"
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
           - "pydoclint"
           - "pytest-asyncio"
       # We group repo-config updates as it uses optional dependencies that are
@@ -49,10 +52,13 @@ updates:
       # each if we don't group them.
       repo-config:
         patterns:
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[{{ cookiecutter.type }}]"
+          - "frequenz-repo-config[extra-lint-examples]"
       mkdocstrings:
         patterns:
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/dependabot.yml
@@ -34,11 +34,14 @@ updates:
           - "minor"
         exclude-patterns:
           - "async-solipsism"
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[actor]"
+          - "frequenz-repo-config[extra-lint-examples]"
           - "markdown-callouts"
           - "mkdocs-gen-files"
           - "mkdocs-literate-nav"
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
           - "pydoclint"
           - "pytest-asyncio"
       # We group repo-config updates as it uses optional dependencies that are
@@ -46,10 +49,13 @@ updates:
       # each if we don't group them.
       repo-config:
         patterns:
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[actor]"
+          - "frequenz-repo-config[extra-lint-examples]"
       mkdocstrings:
         patterns:
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/dependabot.yml
@@ -35,11 +35,14 @@ updates:
         exclude-patterns:
           - "async-solipsism"
           - "frequenz-api-common"
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[api]"
+          - "frequenz-repo-config[extra-lint-examples]"
           - "markdown-callouts"
           - "mkdocs-gen-files"
           - "mkdocs-literate-nav"
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
           - "pydoclint"
           - "pytest-asyncio"
       # We group repo-config updates as it uses optional dependencies that are
@@ -47,10 +50,13 @@ updates:
       # each if we don't group them.
       repo-config:
         patterns:
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[api]"
+          - "frequenz-repo-config[extra-lint-examples]"
       mkdocstrings:
         patterns:
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/dependabot.yml
@@ -34,11 +34,14 @@ updates:
           - "minor"
         exclude-patterns:
           - "async-solipsism"
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[app]"
+          - "frequenz-repo-config[extra-lint-examples]"
           - "markdown-callouts"
           - "mkdocs-gen-files"
           - "mkdocs-literate-nav"
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
           - "pydoclint"
           - "pytest-asyncio"
       # We group repo-config updates as it uses optional dependencies that are
@@ -46,10 +49,13 @@ updates:
       # each if we don't group them.
       repo-config:
         patterns:
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[app]"
+          - "frequenz-repo-config[extra-lint-examples]"
       mkdocstrings:
         patterns:
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/dependabot.yml
@@ -34,11 +34,14 @@ updates:
           - "minor"
         exclude-patterns:
           - "async-solipsism"
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[lib]"
+          - "frequenz-repo-config[extra-lint-examples]"
           - "markdown-callouts"
           - "mkdocs-gen-files"
           - "mkdocs-literate-nav"
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
           - "pydoclint"
           - "pytest-asyncio"
       # We group repo-config updates as it uses optional dependencies that are
@@ -46,10 +49,13 @@ updates:
       # each if we don't group them.
       repo-config:
         patterns:
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[lib]"
+          - "frequenz-repo-config[extra-lint-examples]"
       mkdocstrings:
         patterns:
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/dependabot.yml
@@ -34,11 +34,14 @@ updates:
           - "minor"
         exclude-patterns:
           - "async-solipsism"
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[model]"
+          - "frequenz-repo-config[extra-lint-examples]"
           - "markdown-callouts"
           - "mkdocs-gen-files"
           - "mkdocs-literate-nav"
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
           - "pydoclint"
           - "pytest-asyncio"
       # We group repo-config updates as it uses optional dependencies that are
@@ -46,10 +49,13 @@ updates:
       # each if we don't group them.
       repo-config:
         patterns:
-          - "frequenz-repo-config*"
+          - "frequenz-repo-config"
+          - "frequenz-repo-config[model]"
+          - "frequenz-repo-config[extra-lint-examples]"
       mkdocstrings:
         patterns:
           - "mkdocstrings*"
+          - "mkdocstrings[python]"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
It seems like dependabot wildcard doesn't work when [] is involved, so we need to put optional dependencies explicitly in the include/exclude patterns.
