### PR TITLE
Add warning about requests dependencies to golden tests

### DIFF
--- a/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stderr.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/cookiecutter-stderr.txt
@@ -1,0 +1,2 @@
+/home/luca/devel/repo-config/.direnv/python-3.12/lib/python3.12/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
+  warnings.warn(

--- a/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stderr.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/api/cookiecutter-stderr.txt
@@ -1,0 +1,2 @@
+/home/luca/devel/repo-config/.direnv/python-3.12/lib/python3.12/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
+  warnings.warn(

--- a/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stderr.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/app/cookiecutter-stderr.txt
@@ -1,0 +1,2 @@
+/home/luca/devel/repo-config/.direnv/python-3.12/lib/python3.12/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
+  warnings.warn(

--- a/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stderr.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/cookiecutter-stderr.txt
@@ -1,0 +1,2 @@
+/home/luca/devel/repo-config/.direnv/python-3.12/lib/python3.12/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
+  warnings.warn(

--- a/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stderr.txt
+++ b/tests_golden/integration/test_cookiecutter_generation/model/cookiecutter-stderr.txt
@@ -1,0 +1,2 @@
+/home/luca/devel/repo-config/.direnv/python-3.12/lib/python3.12/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
+  warnings.warn(


### PR DESCRIPTION
We are currently having CI failures because there are some issues with transitive dependencies. It is already [fixed upstream](https://github.com/psf/requests/pull/7220) but not release yet. For now we just adjust golden tests to expect these warnings.

We will have to roll this back when upstream is fixed.

Workaround for #527.