### PR TITLE
Fix tests by adding dependency constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ dev-pytest = [
   "cookiecutter == 2.6.0", # For checking the cookiecutter scripts
   "jinja2 == 3.1.6", # For checking the cookiecutter scripts
   "sybil >= 6.1.1, < 10", # Should be consistent with the extra-lint-examples dependency
+  # This is a hack to overcome an outdated version check in requests, see
+  # https://github.com/frequenz-floss/frequenz-repo-config-python/issues/527
+  "chardet < 6",
 ]
 dev = [
   "frequenz-repo-config[dev-mkdocs,dev-flake8,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",


### PR DESCRIPTION
We are currently having CI failures because there are some issues with transitive dependencies. It is already fixed upstream but not release yet.

We temporarily restrict chardet version to < 6 in tests to avoid these warnings.

Workaround for #527.
