### PR TITLE
ci: Fix runner for publish-to-pypi

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -314,7 +314,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Frequenz Repository Configuration Release Notes
 
+> [!NOTE]
+> This is a bugfix release for v0.15.0. This release was never published to PyPI, so we keep the entire release notes for v0.15.0 here (updated to the new changes) to make it easier for users to upgrade from v0.14.0 to v0.15.x.
+>
+> The only change with respect to v0.15.0 is using the appropriate job runner for the `publish-to-pypi` job in `ci.yaml`. v0.15.0 updated it to `ubuntu-slim` but that didn't work because it requires Docker, and it is not installed on the `ubuntu-slim` runner.
+
 ## Summary
 
 This release reduces CI cost by moving lightweight GitHub Actions jobs to the new `ubuntu-slim` runner, fixes Dependabot auto-merge/merge-queue issues by switching to a GitHub App installation token, and introduces an automated repo-config migration workflow (including updating existing repos' version-branch protection defaults).
@@ -28,12 +33,14 @@ But you might still need to adapt your code:
 
 - Migrated lightweight workflow jobs to use the new `ubuntu-slim` runner for cost savings.
   The following jobs now use `ubuntu-slim`:
-  - `ci.yaml`: `protolint`, `nox-all`, `test-installation-all`, `create-github-release`, `publish-to-pypi`
+  - `ci.yaml`: `protolint`, `nox-all`, `test-installation-all`, `create-github-release`
   - `ci-pr.yaml`: `protolint`
   - `auto-dependabot.yaml`: `auto-merge`
   - `release-notes-check.yml`: `check-release-notes`
   - `dco-merge-queue.yml`: `DCO`
   - `labeler.yml`: `Label`
+
+- Migrated the `publish-to-pypi` job in `ci.yaml` from `ubuntu-latest` to `ubuntu-24.04` to get reproducible builds.
 
 - Added the [`flake8-datetimez`](https://github.com/pjknkda/flake8-datetimez) plugin to the `flake8` session. This plugin prevents accidental use of naive `datetime` objects by flagging calls that create or return datetimes without timezone information.
 

--- a/cookiecutter/migrate.py
+++ b/cookiecutter/migrate.py
@@ -42,6 +42,9 @@ def main() -> None:
     print("Migrating workflows to use ubuntu-slim runner for lightweight jobs...")
     migrate_to_ubuntu_slim()
     print("=" * 72)
+    print("Migrating publish-to-pypi workflow runner to ubuntu-24.04...")
+    migrate_publish_to_pypi_runner()
+    print("=" * 72)
     print("Migrating pyproject license metadata to SPDX format...")
     migrate_pyproject_license()
     print("=" * 72)
@@ -94,9 +97,7 @@ def migrate_to_ubuntu_slim() -> None:
     """
     workflows_dir = Path(".github") / "workflows"
     project_type = read_project_type()
-    github_org = read_cookiecutter_github_org()
     include_protolint = project_type == "api"
-    include_publish_to_pypi = github_org == "frequenz-floss"
     if project_type is None:
         include_protolint = True
         manual_step(
@@ -178,19 +179,6 @@ def migrate_to_ubuntu_slim() -> None:
             }
         ],
     }
-    if include_publish_to_pypi:
-        migrations["ci.yaml"].append(
-            {
-                "job": "publish-to-pypi",
-                "old": (
-                    '    needs: ["create-github-release"]\n    runs-on: ubuntu-24.04'
-                ),
-                "new": (
-                    '    needs: ["create-github-release"]\n    runs-on: ubuntu-slim'
-                ),
-            }
-        )
-
     if include_protolint:
         protolint_rule = {
             "job": "protolint",
@@ -236,6 +224,39 @@ def migrate_to_ubuntu_slim() -> None:
                 f"  Pattern not found in {filepath}: please switch job {job} to use "
                 "`runs-on: ubuntu-slim` where appropriate."
             )
+
+
+def migrate_publish_to_pypi_runner() -> None:
+    """Migrate the publish-to-pypi CI job runner to ubuntu-24.04."""
+    github_org = read_cookiecutter_github_org()
+    if github_org != "frequenz-floss":
+        print("  Skipping .github/workflows/ci.yaml (publish-to-pypi not expected)")
+        return
+
+    filepath = Path(".github") / "workflows" / "ci.yaml"
+    if not filepath.exists():
+        print(f"  Skipping {filepath} (file not found)")
+        return
+
+    old = '    needs: ["create-github-release"]\n    runs-on: ubuntu-latest'
+    new = '    needs: ["create-github-release"]\n    runs-on: ubuntu-24.04'
+    content = filepath.read_text(encoding="utf-8")
+
+    if old in content:
+        replace_file_contents_atomically(filepath, old, new)
+        print(f"  Updated {filepath}: migrated runner for job publish-to-pypi")
+        return
+
+    if new in content:
+        print(
+            f"  Skipped {filepath}: runner already up to date for job publish-to-pypi"
+        )
+        return
+
+    manual_step(
+        f"  Pattern not found in {filepath}: please switch the runner for job "
+        "publish-to-pypi according to the latest template."
+    )
 
 
 def migrate_pyproject_license() -> None:  # pylint: disable=too-many-branches

--- a/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
+++ b/cookiecutter/{{cookiecutter.github_repo_name}}/.github/workflows/ci.yaml
@@ -366,7 +366,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

--- a/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/actor/frequenz-actor-test/.github/workflows/ci.yaml
@@ -333,7 +333,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

--- a/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/api/frequenz-api-test/.github/workflows/ci.yaml
@@ -363,7 +363,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

--- a/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/app/frequenz-app-test/.github/workflows/ci.yaml
@@ -333,7 +333,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

--- a/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/lib/frequenz-test-python/.github/workflows/ci.yaml
@@ -333,7 +333,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

--- a/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
+++ b/tests_golden/integration/test_cookiecutter_generation/model/frequenz-model-test/.github/workflows/ci.yaml
@@ -333,7 +333,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/


### PR DESCRIPTION
The `pypa/gh-action-pypi-publish` action needs docker to run, and the ubuntu-slim runner doesn't provide docker, so we need to use a full ubuntu image instead.

The migration script is also updated to update the runner to ubuntu-24.04 to get reproducible builds (it was ubuntu-latest before).
