### PR TITLE
Fix the cookiecutter migration script template

### DIFF
--- a/.github/cookiecutter-migrate.template.py
+++ b/.github/cookiecutter-migrate.template.py
@@ -58,7 +58,6 @@ def main() -> None:
 
     print("\033[0;32m       ✅ Migration script finished successfully ✅\033[0m")
     print()
-    return project_type
 
 
 def apply_patch(patch_content: str) -> None:

--- a/.github/cookiecutter-migrate.template.py
+++ b/.github/cookiecutter-migrate.template.py
@@ -20,7 +20,8 @@ for each version.
 And remember to follow any manual instructions for each run.
 """  # noqa: E501
 
-# pylint: disable=too-many-lines, too-many-locals, too-many-branches
+# R0801 is similarity detection, as the template is always similar to the current script
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, R0801
 
 import hashlib
 import json

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,6 +9,7 @@ from frequenz.repo.config.nox import default
 config = default.lib_config.copy()
 config.extra_paths.extend(
     [
+        ".github/cookiecutter-migrate.template.py",
         "cookiecutter/hooks",
         "cookiecutter/local_extensions.py",
         "cookiecutter/migrate.py",


### PR DESCRIPTION
 The file had a left-over of a bad merge.

We also start checking the file to avoid this happening undetected again. For this we need a minor extra fix (disable similarity detection for the migration script, as it is always similar to the current instance).
