### PR TITLE
black: Exclude template files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ Support = "https://github.com/frequenz-floss/frequenz-repo-config-python/discuss
 line-length = 88
 target-version = ['py311']
 include = '\.pyi?$'
+extend-exclude = '^/cookiecutter/{{cookiecutter.github_repo_name}}/'
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
The template files are jinja templates, so they can't be parsed by black. This is not relevant when running black via `nox` because it passes path explicitly (and does not include the template directory), but it is useful when doing `black .`, like the black auto-migration action.

This should fix the failing migration in #578.
