### PR TITLE
Fix and improve docstring documentation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,9 +28,15 @@ But you might still need to adapt your code:
 
 - Generated `pyproject.toml` no longer sets `addopts = "-vv"` under `[tool.pytest.ini_options]` as this is too verbose for a default.
 
+## Enhancements
+
+- Improved the docstring documentation and cross-references across the `frequenz.repo.config` package.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+
+- Fixed several typos and broken code examples in the docstrings.
 
 ### Cookiecutter template
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
+            relative_crossrefs: true
           inventories:
             - https://cookiecutter.readthedocs.io/en/stable/objects.inv
             - https://docs.python.org/3/objects.inv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,9 @@ check-yield-types = false
 arg-type-hints-in-docstring = false
 arg-type-hints-in-signature = true
 allow-init-docstring = true
-check-class-attributes = false
+check-class-attributes = true
+check-style-mismatch = true
+require-inline-class-var-docs = true
 
 [tool.pylint.similarities]
 ignore-comments = ['yes']

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -210,7 +210,7 @@ answer no and copy the list of missing stubs to the `pyproject.toml` file.
 
 ### API reference generation
 
-The API documnentation can be automatically generated from the source files using the
+The API documentation can be automatically generated from the source files using the
 [`frequenz.repo.config.mkdocs`][] package as when run as a
 [`mkdocs-gen-files`](https://oprypin.github.io/mkdocs-gen-files/) plugin script.
 
@@ -228,7 +228,7 @@ plugins:
 
 By default this script will look for files in the `src/` directory and generate the
 documentation files in the `python-reference/` directory inside `mkdocs` output directory
-(`site` by defaul).
+(`site` by default).
 
 If you need to customize the above paths, you can create a new script to use with the
 `mkdocs-gen-files` plugin as follows:
@@ -325,7 +325,7 @@ linting the examples in your code's *docstrings*.
 
 # APIs
 
-## Protobuf configuation
+## Protobuf configuration
 
 Support is provided to generate files from *protobuf* files.  To do this, it is possible
 to configure the options to use while generating the files for different purposes
@@ -425,7 +425,7 @@ to make sure the generated files are included in the wheel:
 [tool.setuptools.package-data]
 "*" = ["*.pyi"]
 
-[tools.pytest.ini_options]
+[tool.pytest.ini_options]
 testpaths = ["pytests"]
 ```
 

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -5,7 +5,7 @@ r"""Frequenz project setup tools and common configuration.
 
 The tools are provided to configure the main types of repositories most commonly used at
 Frequenz, defined in
-[`frequenz.repo.config.RepositoryType`][].
+[`RepositoryType`][.RepositoryType].
 
 - actor: SDK actors
 - api: gRPC APIs
@@ -20,14 +20,14 @@ Frequenz, defined in
 ### Writing the `noxfile.py`
 
 Projects wanting to use `nox` to run lint checkers and other utilities can use
-the [`frequenz.repo.config.nox`][] package.
+the [`nox`][.nox] package.
 
 When writing the `noxfile.py` you should import the `nox` module from this
-package and use the [`frequenz.repo.config.nox.configure`][] function,
+package and use the [`nox.configure`][.nox.configure] function,
 which will configure all nox sessions.
 
 To use the default options, you should call `configure()` using one of the [repository
-types][frequenz.repo.config.RepositoryType].  For example:
+types][.RepositoryType].  For example:
 
 ```python
 from frequenz.repo.config import RepositoryType, nox
@@ -39,8 +39,8 @@ Again, make sure to pick the correct project default configuration based on the 
 your project (`actor_config`, `api_config`, `app_config`, `lib_config`, `model_config`).
 
 If you need to use some custom configuration, you can start from the default settings in
-the [`frequenz.repo.config.nox.default`][] module,
-[copying][frequenz.repo.config.nox.config.Config.copy] it and changing whatever you
+the [`nox.default`][.nox.default] module,
+[copying][.nox.config.Config.copy] it and changing whatever you
 need to customize.  For example:
 
 ```python
@@ -61,15 +61,15 @@ nox.configure(config)
 If you need further customization or to define new sessions, you can use the
 following modules:
 
-- [`frequenz.repo.config.nox.config`][]: Low-level utilities to configure nox
+- [`nox.config`][.nox.config]: Low-level utilities to configure nox
   sessions. It defines the `Config` and `CommandsOptions` classes and the actual
   implementation of the `configure()` function. It also defines the `get()`
   function, which can be used to get the currently used configuration object.
 
-- [`frequenz.repo.config.nox.session`][]: Predefined nox sessions. These are
+- [`nox.session`][.nox.session]: Predefined nox sessions. These are
   the sessions that are used by default.
 
-- [`frequenz.repo.config.nox.util`][]: General purpose utility functions.
+- [`nox.util`][.nox.util]: General purpose utility functions.
 
 ### `pyproject.toml` configuration
 
@@ -211,7 +211,7 @@ answer no and copy the list of missing stubs to the `pyproject.toml` file.
 ### API reference generation
 
 The API documentation can be automatically generated from the source files using the
-[`frequenz.repo.config.mkdocs`][] package as when run as a
+[`mkdocs`][.mkdocs] package as when run as a
 [`mkdocs-gen-files`](https://oprypin.github.io/mkdocs-gen-files/) plugin script.
 
 To enable it you just need to make sure the `mkdocs-gen-files`, `mkdocs-literate-nav`
@@ -276,7 +276,7 @@ To do so there is some setup that's needed:
     Unfortunately, because of how Sybil works, the [`Sybil`][sybil.Sybil] class needs to
     be instantiated in the `conftest.py` file. To easily do this, the convenience
     function
-    [`get_sybil_arguments()`][frequenz.repo.config.pytest.examples.get_sybil_arguments]
+    [`get_sybil_arguments()`][.pytest.examples.get_sybil_arguments]
     is provided to get the arguments to pass to the `Sybil()` constructor to be able to
     collect and lint the examples.
 

--- a/src/frequenz/repo/config/__init__.py
+++ b/src/frequenz/repo/config/__init__.py
@@ -62,7 +62,7 @@ If you need further customization or to define new sessions, you can use the
 following modules:
 
 - [`frequenz.repo.config.nox.config`][]: Low-level utilities to configure nox
-  sessions. It defines the `Config` and CommandsOptions` classes and the actual
+  sessions. It defines the `Config` and `CommandsOptions` classes and the actual
   implementation of the `configure()` function. It also defines the `get()`
   function, which can be used to get the currently used configuration object.
 
@@ -111,7 +111,7 @@ The following optional dependencies are used and must be defined:
 
   - `pytest`: To run the tests.
 
-For some of these you should install too any other dependencies that are used
+For some of these you should also install any other dependencies that are used
 by the project. For example, if the project uses `pytest-asyncio`, you should
 include it in the `dev-pytest` optional dependency.
 
@@ -189,7 +189,7 @@ strict = true
 You can just call `mypy` to check the package of your sources or you can use `mypy
 tests` to check the tests, for example.
 
-You might also need to extra optional dependencies to install type checking stubs for
+You might also need to add extra optional dependencies to install type checking stubs for
 some packages.  For example for API projects you need the `grpc-stubs` package:
 
 ```toml
@@ -202,7 +202,7 @@ dev-mypy = [
 ]
 ```
 
-You can use `mypy --install-types` to install to get a list of missing stubs, `mypy`
+You can use `mypy --install-types` to get a list of missing stubs, `mypy`
 will list them for you and ask if you want to proceed with the installation.  You can
 answer no and copy the list of missing stubs to the `pyproject.toml` file.
 
@@ -308,7 +308,7 @@ To do so there is some setup that's needed:
     ```
 
    This will make sure that you have the appropriate dependencies installed to run the
-   the tests linting and that `mypy` doesn't complain about the `sybil` module not being
+   tests linting and that `mypy` doesn't complain about the `sybil` module not being
    typed.
 
 3. Exclude the `src/conftest.py` file from the distribution package, as it shouldn't be
@@ -366,7 +366,7 @@ api_pages.generate_protobuf_api_pages()
 ```
 
 This will use the configuration in the `pyproject.toml` file and requires `docker` to
-run (it uses the `pseudomuto/protoc-gen-doc` docker image.
+run (it uses the `pseudomuto/protoc-gen-doc` docker image).
 
 ### `setuptools` gRPC support
 

--- a/src/frequenz/repo/config/_core.py
+++ b/src/frequenz/repo/config/_core.py
@@ -1,7 +1,7 @@
 # License: MIT
 # Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
-"""Base types used accross the project."""
+"""Base types used across the project."""
 
 import enum as _enum
 

--- a/src/frequenz/repo/config/cli/version/mike/info.py
+++ b/src/frequenz/repo/config/cli/version/mike/info.py
@@ -3,7 +3,7 @@
 
 """Command-line tool to get the current `mike` version information of a repository.
 
-For now this tool is designed to be used in GitHub Actions workflows, but is is possible
+For now this tool is designed to be used in GitHub Actions workflows, but it is possible
 to use it in other environments as well. To do so the `gh` tool should be properly
 configured and have at least read-access to the repository, and the following environment
 variables should be set:

--- a/src/frequenz/repo/config/github.py
+++ b/src/frequenz/repo/config/github.py
@@ -3,14 +3,14 @@
 
 """Utilities to work with GitHub.
 
-- [`abort()`][frequenz.repo.config.github.abort] to print an error message using GitHub
+- [`abort()`][.abort] to print an error message using GitHub
     Actions commands and exit.
-- [`require_env()`][frequenz.repo.config.github.require_env] to get an environment
+- [`require_env()`][.require_env] to get an environment
     variable or exit with an error if it is not defined.
-- [`get_tags()`][frequenz.repo.config.github.get_tags] to get the tags of a repository.
-- [`get_branches()`][frequenz.repo.config.github.get_branches] to get the branches of a
+- [`get_tags()`][.get_tags] to get the tags of a repository.
+- [`get_branches()`][.get_branches] to get the branches of a
     repository.
-- [`configure_logging()`][frequenz.repo.config.github.configure_logging] to configure
+- [`configure_logging()`][.configure_logging] to configure
     logging for GitHub Actions.
 """
 
@@ -192,7 +192,7 @@ def configure_logging(level: int | None = None) -> None:
     """Configure logging for GitHub Actions.
 
     The
-    [`GitHubActionsFormatter`][frequenz.repo.config.github.GitHubActionsFormatter]
+    [`GitHubActionsFormatter`][..GitHubActionsFormatter]
     is used to format the logs, using [GitHub Action
     commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions).
 

--- a/src/frequenz/repo/config/mkdocs/annotations.py
+++ b/src/frequenz/repo/config/mkdocs/annotations.py
@@ -11,8 +11,8 @@ Normally annotations are shown with a `(+)` button that expands the annotation. 
 able to explain code step by step, it is good to have annotations with numbers, shown as
 `(1)`, `(2)`, etc., to be able to follow the notes in a particular order.
 
-To do this, we need some custom CSS rules. Before this customization was officially
-supported and documented, but now they are not officially supported anymore, so it could
+To do this, we need some custom CSS rules. This customization was previously officially
+supported and documented, but it is not officially supported anymore, so it could
 eventually break (it already did once).
 
 If that happens we either need to look into how to fix the CSS ourselves or remove the
@@ -47,7 +47,7 @@ The CSS file should contain the following rules:
 
 # Macros integration
 
-If you want to show an example on how an annotation looks like, you can use the
+If you want to show an example of how an annotation looks, you can use the
 [`CODE_ANNOTATION_MARKER`][frequenz.repo.config.mkdocs.annotations.CODE_ANNOTATION_MARKER]
 variable to inject the appropriate HTML code. See
 [frequenz.repo.config.mkdocs.mkdocstrings_macros][] for more information.

--- a/src/frequenz/repo/config/mkdocs/annotations.py
+++ b/src/frequenz/repo/config/mkdocs/annotations.py
@@ -48,9 +48,9 @@ The CSS file should contain the following rules:
 # Macros integration
 
 If you want to show an example of how an annotation looks, you can use the
-[`CODE_ANNOTATION_MARKER`][frequenz.repo.config.mkdocs.annotations.CODE_ANNOTATION_MARKER]
+[`CODE_ANNOTATION_MARKER`][.CODE_ANNOTATION_MARKER]
 variable to inject the appropriate HTML code. See
-[frequenz.repo.config.mkdocs.mkdocstrings_macros][] for more information.
+[`mkdocstrings_macros`][..mkdocstrings_macros] for more information.
 
 # References
 

--- a/src/frequenz/repo/config/mkdocs/api_pages.py
+++ b/src/frequenz/repo/config/mkdocs/api_pages.py
@@ -49,7 +49,7 @@ def generate_python_api_pages(
     not included.
 
     A summary page is generated as `SUMMARY.md` which is compatible with the
-    `mkdocs-literary-nav` plugin.
+    `mkdocs-literate-nav` plugin.
 
     Args:
         src_path: Path where the code is located.

--- a/src/frequenz/repo/config/mkdocs/api_pages.py
+++ b/src/frequenz/repo/config/mkdocs/api_pages.py
@@ -23,13 +23,13 @@ from .. import protobuf as _protobuf
 
 
 def _is_internal(path_parts: Tuple[str, ...]) -> bool:
-    """Tell if the path is internal judging by the parts.
+    """Return whether the path is internal, judging by its parts.
 
     Args:
         path_parts: Path.parts of the path to check.
 
     Returns:
-        True if the path is internal.
+        Whether the path is internal.
     """
 
     def with_underscore_not_init(part: str) -> bool:

--- a/src/frequenz/repo/config/mkdocs/api_pages.py
+++ b/src/frequenz/repo/config/mkdocs/api_pages.py
@@ -6,7 +6,7 @@
 It uses the following `mkdocs` plugins:
 
 * `mkdocs-gen-files` to generate the API documentation pages.
-* `mkdocs-literate-nav` to make use of the generate `SUMMARY.md` file.
+* `mkdocs-literate-nav` to make use of the generated `SUMMARY.md` file.
 
 Based on the recipe at:
 https://mkdocstrings.github.io/recipes/#automatic-code-reference-pages
@@ -45,7 +45,7 @@ def generate_python_api_pages(
 ) -> None:
     """Generate API documentation pages for the code.
 
-    Internal modules (those starting with an underscore except from `__init__`) are
+    Internal modules (those starting with an underscore except for `__init__`) are
     not included.
 
     A summary page is generated as `SUMMARY.md` which is compatible with the
@@ -87,13 +87,10 @@ def generate_python_api_pages(
 def generate_protobuf_api_pages(
     src_path: str = "proto", dst_path: str = "protobuf-reference"
 ) -> None:
-    """Generate API documentation pages for the code.
-
-    Internal modules (those starting with an underscore except from `__init__`) are
-    not included.
+    """Generate API documentation pages for the protocol buffer files.
 
     A summary page is generated as `SUMMARY.md` which is compatible with the
-    `mkdocs-literary-nav` plugin.
+    `mkdocs-literate-nav` plugin.
 
     Args:
         src_path: Path where the code is located.

--- a/src/frequenz/repo/config/mkdocs/mike.py
+++ b/src/frequenz/repo/config/mkdocs/mike.py
@@ -6,11 +6,11 @@
 This module provides these tools:
 
 * Building the mike version information from the repository information
-  ([`build_mike_version()`][frequenz.repo.config.mkdocs.mike.build_mike_version]).
+  ([`build_mike_version()`][.build_mike_version]).
 * Sorting the mike version information `version.json` file
-  ([`sort_mike_versions()`][frequenz.repo.config.mkdocs.mike.sort_mike_versions]).
+  ([`sort_mike_versions()`][.sort_mike_versions]).
 * Comparing mike versions
-  ([`compare_mike_version()`][frequenz.repo.config.mkdocs.mike.compare_mike_version]).
+  ([`compare_mike_version()`][.compare_mike_version]).
 
 Mike versions have the format `vX.Y(-pre|-dev)?`, where `X` is the major version, `Y` is
 the minor version, and the optional suffix is either `-pre` for pre-release versions or
@@ -233,7 +233,7 @@ def sort_mike_versions(versions: list[str], *, reverse: bool = True) -> list[str
     - Other versions appear first and are sorted alphabetically.
 
     The versions are sorted in-place using
-    [`compare_mike_version()`][frequenz.repo.config.mkdocs.mike.compare_mike_version].
+    [`compare_mike_version()`][..compare_mike_version].
 
     Example:
 

--- a/src/frequenz/repo/config/mkdocs/mike.py
+++ b/src/frequenz/repo/config/mkdocs/mike.py
@@ -22,7 +22,7 @@ then they have the format `vX.Y-pre`. Development branches have the format `vX.Y
 * Tag `v1.0.0` -> `v1.0`
 * Tag `v2.1.0-alpha.1` -> `v2.1-pre`
 * Branch `v1.x.x` (with no releases) -> `v1.0-dev`
-* Branch `v1.x.x (with releases an existing release, for example `v1.0.0`) -> `v1.1-dev`
+* Branch `v1.x.x` (with an existing release, for example `v1.0.0`) -> `v1.1-dev`
 * Branch `v1.1.x` -> `v1.1-dev`
 
 Aliases have the format `vX(-pre|-dev)?`, where `X` is the major version and the
@@ -61,7 +61,7 @@ class MikeVersionInfo:
 def build_mike_version(repo_info: RepoVersionInfo) -> MikeVersionInfo:
     """Build the mike version information from the given repository information.
 
-    The version is build based on if a tag or a branch is checked out.
+    The version is built based on whether a tag or a branch is checked out.
 
     For tags, the title is the tag name, the version is "vX.Y", where X is the major
     version and Y is the minor version of the tag. If the tag is the last minor version

--- a/src/frequenz/repo/config/mkdocs/mike.py
+++ b/src/frequenz/repo/config/mkdocs/mike.py
@@ -17,7 +17,7 @@ the minor version, and the optional suffix is either `-pre` for pre-release vers
 `-dev` for development versions.
 
 Stable (tagged) versions have the format `vX.Y`, unless they are pre-release versions,
-then they have the format `vX.Y-pre`. Develoment branches have the format `vX.Y-dev`.
+then they have the format `vX.Y-pre`. Development branches have the format `vX.Y-dev`.
 
 * Tag `v1.0.0` -> `v1.0`
 * Tag `v2.1.0-alpha.1` -> `v2.1-pre`

--- a/src/frequenz/repo/config/mkdocs/mkdocstrings_macros.py
+++ b/src/frequenz/repo/config/mkdocs/mkdocstrings_macros.py
@@ -31,14 +31,15 @@ This will do the hooking and provide some useful variables and filters:
 
 * [`slugify`][frequenz.repo.config.mkdocs.mkdocstrings_macros.slugify]: A filter to
     slugify a text. Useful to generate anchors for headings.
-* [`code_annotation_marker`]: A variable to inject the appropriate HTML code for showing
-    an example code annotation as a number (see
-    [frequenz.repo.config.mkdocs.annotations][] for more information).
-* [`version`]: A variable with the version information of the repository as exposed by
+* [`code_annotation_marker`][..annotations.CODE_ANNOTATION_MARKER]: A variable
+    to inject the appropriate HTML code for showing an example code annotation
+    as a number (see the [`annotations` module][..annotations] for more
+    information).
+* `version`: A variable with the version information of the repository as exposed by
     [`get_repo_version_info()`][frequenz.repo.config.github.get_repo_version_info],
-    which means some environment variables are required (this variable will be `None`
-    otherwise), please read the function documentation for more details.
-* [`version_requirement`]: A variable with the version requirement for the current
+    which means some environment variables are required (this variable will be
+    `None` otherwise), please read the function documentation for more details.
+* `version_requirement`: A variable with the version requirement for the current
     version of the repository. It is built using the information from `version`. Also
     only available if the right environment variables are set, and if the resulting
     version is a tag (will be empty for branches). If you want to get the version
@@ -67,8 +68,9 @@ plugins:
 ```
 
 Then you need to add the `define_env()` function to the `path/to/macros.py` file.
-A convenience [`hook_env_with_everything()`] is provided to pull all the same default
-variables and filters and call the hooking function at the end as with the *pluglet*.
+A convenience [`hook_env_with_everything()`][.hook_env_with_everything] is provided to
+pull all the same default variables and filters and call the hooking function at the end
+as with the *pluglet*.
 
 You also need to make sure to call the function at the end, after you define your own
 variables, filters and macros. You can optionally pass a `repo_url` in this case so the
@@ -146,11 +148,12 @@ def add_version_variables(
 
     This function will add 2 new macro variables to `env`:
 
-    * [`version`]: A variable with the version information of the repository as exposed by
+    * `version`: A variable with the version information of the repository as exposed by
         [`get_repo_version_info()`][frequenz.repo.config.github.get_repo_version_info],
-        which means some environment variables are required (this variable will be `None`
-        otherwise), please read the function documentation for more details.
-    * [`version_requirement`]: A variable with the version requirement for the current
+        which means some environment variables are required (this variable will
+        be `None` otherwise), please read the function documentation for more
+        details.
+    * `version_requirement`: A variable with the version requirement for the current
         version of the repository. It is built using the information from `version`. Also
         only available if the right environment variables are set, and if the resulting
         version is a tag (will be empty for branches). If you want to get the version

--- a/src/frequenz/repo/config/mkdocs/mkdocstrings_macros.py
+++ b/src/frequenz/repo/config/mkdocs/mkdocstrings_macros.py
@@ -34,13 +34,13 @@ This will do the hooking and provide some useful variables and filters:
 * [`code_annotation_marker`]: A variable to inject the appropriate HTML code for showing
     an example code annotation as a number (see
     [frequenz.repo.config.mkdocs.annotations][] for more information).
-* [`version`]: A varaible with the version information of the repository as exposed by
+* [`version`]: A variable with the version information of the repository as exposed by
     [`get_repo_version_info()`][frequenz.repo.config.github.get_repo_version_info],
     which means some environment variables are required (this variable will be `None`
     otherwise), please read the function documentation for more details.
 * [`version_requirement`]: A variable with the version requirement for the current
     version of the repository. It is built using the information from `version`. Also
-    only available if the rigth environment variables are set, and if the resulting
+    only available if the right environment variables are set, and if the resulting
     version is a tag (will be empty for branches). If you want to get the version
     requirement for a branch, you need to provide a `repo_url` variable in the
     `mkdocs.yaml` file or do a custom setup. Please read the [Customized usage]
@@ -146,13 +146,13 @@ def add_version_variables(
 
     This function will add 2 new macro variables to `env`:
 
-    * [`version`]: A varaible with the version information of the repository as exposed by
+    * [`version`]: A variable with the version information of the repository as exposed by
         [`get_repo_version_info()`][frequenz.repo.config.github.get_repo_version_info],
         which means some environment variables are required (this variable will be `None`
         otherwise), please read the function documentation for more details.
     * [`version_requirement`]: A variable with the version requirement for the current
         version of the repository. It is built using the information from `version`. Also
-        only available if the rigth environment variables are set, and if the resulting
+        only available if the right environment variables are set, and if the resulting
         version is a tag (will be empty for branches). If you want to get the version
         requirement for a branch, you need to provide a `repo_url` or a `repo_url`
         config in the `mkdocs.yml` file.

--- a/src/frequenz/repo/config/mkdocs/mkdocstrings_macros.py
+++ b/src/frequenz/repo/config/mkdocs/mkdocstrings_macros.py
@@ -29,7 +29,7 @@ plugins:
 
 This will do the hooking and provide some useful variables and filters:
 
-* [`slugify`][frequenz.repo.config.mkdocs.mkdocstrings_macros.slugify]: A filter to
+* [`slugify`][.slugify]: A filter to
     slugify a text. Useful to generate anchors for headings.
 * [`code_annotation_marker`][..annotations.CODE_ANNOTATION_MARKER]: A variable
     to inject the appropriate HTML code for showing an example code annotation
@@ -94,7 +94,7 @@ def define_env(env: macros.MacrosPlugin) -> None:
 If you don't want to pull in all the default variables and filters, you can still define
 your own `define_env()` function and do the same configuration in the `mkdocs.yml` file
 as in the [Customized usage] section, but instead call the
-[`hook_macros_plugin()`][frequenz.repo.config.mkdocs.mkdocstrings_macros.hook_macros_plugin]
+[`hook_macros_plugin()`][.hook_macros_plugin]
 at the end.
 
 Here is an example of how to do it:
@@ -235,7 +235,7 @@ def hook_env_with_everything(
 
     This function is a convenience function that adds all variables and filters and
     macros provided by this module and calls
-    [`hook_macros_plugin()`][frequenz.repo.config.mkdocs.mkdocstrings_macros.hook_macros_plugin]
+    [`hook_macros_plugin()`][..hook_macros_plugin]
     at the end.
 
     Args:

--- a/src/frequenz/repo/config/nox/__init__.py
+++ b/src/frequenz/repo/config/nox/__init__.py
@@ -37,7 +37,7 @@ If you need further customization or to define new sessions, you can use the
 following modules:
 
 - [`frequenz.repo.config.nox.config`][]: Low-level utilities to configure nox sessions.
-  It defines the `Config` and CommandsOptions` classes and the actual implementation of
+  It defines the `Config` and `CommandsOptions` classes and the actual implementation of
   the `configure()` function. It also defines the `get()` function, which can be used to
   get the currently used configuration object.
 

--- a/src/frequenz/repo/config/nox/__init__.py
+++ b/src/frequenz/repo/config/nox/__init__.py
@@ -3,11 +3,11 @@
 
 """Utilities to build noxfiles.
 
-The main entry point is the [`configure()`][frequenz.repo.config.nox.configure]
+The main entry point is the [`configure()`][.configure]
 function, which will configure all nox sessions according to some configuration.
 
 To use the default options, you should call `configure()` using one of the [repository
-types][frequenz.repo.config.RepositoryType].  For example:
+types][..RepositoryType].  For example:
 
 ```python
 from frequenz.repo.config import RepositoryType, nox
@@ -20,8 +20,8 @@ of your project (`actor_config`, `api_config`, `app_config`, `lib_config`,
 `model_config`).
 
 If you need to use some custom configuration, you can start from the default settings in
-the [`frequenz.repo.config.nox.default`][] module,
-[copying][frequenz.repo.config.nox.config.Config.copy] it and changing whatever you
+the [`default`][.default] module,
+[copying][.config.Config.copy] it and changing whatever you
 need to customize.  For example:
 
 ```python
@@ -36,15 +36,15 @@ nox.configure(config)
 If you need further customization or to define new sessions, you can use the
 following modules:
 
-- [`frequenz.repo.config.nox.config`][]: Low-level utilities to configure nox sessions.
+- [`config`][.config]: Low-level utilities to configure nox sessions.
   It defines the `Config` and `CommandsOptions` classes and the actual implementation of
   the `configure()` function. It also defines the `get()` function, which can be used to
   get the currently used configuration object.
 
-- [`frequenz.repo.config.nox.session`][]: Predefined nox sessions. These are the
+- [`session`][.session]: Predefined nox sessions. These are the
   sessions that are used by default.
 
-- [`frequenz.repo.config.nox.util`][]: General purpose utility functions.
+- [`util`][.util]: General purpose utility functions.
 """
 
 from .config import configure

--- a/src/frequenz/repo/config/nox/config.py
+++ b/src/frequenz/repo/config/nox/config.py
@@ -27,22 +27,22 @@ class CommandsOptions:
     """Command-line options for each command."""
 
     black: list[str] = _dataclasses.field(default_factory=lambda: [])
-    """Command-line options for the `black` command."""
+    """The command-line options for the `black` command."""
 
     flake8: list[str] = _dataclasses.field(default_factory=lambda: [])
-    """Command-line options for the `flake8` command."""
+    """The command-line options for the `flake8` command."""
 
     isort: list[str] = _dataclasses.field(default_factory=lambda: [])
-    """Command-line options for the `isort` command."""
+    """The command-line options for the `isort` command."""
 
     mypy: list[str] = _dataclasses.field(default_factory=lambda: [])
-    """Command-line options for the `mypy` command."""
+    """The command-line options for the `mypy` command."""
 
     pylint: list[str] = _dataclasses.field(default_factory=lambda: [])
-    """Command-line options for the `pylint` command."""
+    """The command-line options for the `pylint` command."""
 
     pytest: list[str] = _dataclasses.field(default_factory=lambda: [])
-    """Command-line options for the `pytest` command."""
+    """The command-line options for the `pytest` command."""
 
     def copy(self) -> Self:
         """Create a new object as a copy of self.
@@ -66,13 +66,13 @@ class Config:
     """Configuration for nox sessions."""
 
     opts: CommandsOptions = _dataclasses.field(default_factory=CommandsOptions)
-    """Command-line options for each command used by sessions."""
+    """The command-line options for each command used by sessions."""
 
     sessions: list[str] = _dataclasses.field(default_factory=lambda: [])
-    """List of sessions to run."""
+    """The list of sessions to run."""
 
     source_paths: list[str] = _dataclasses.field(default_factory=lambda: [])
-    """List of paths containing source files that should be analyzed by the sessions.
+    """The list of paths containing source files that should be analyzed by the sessions.
 
     Source paths are inspected for `__init__.py` files to look for packages.
     The path should be the top-level directory containing packages that will be
@@ -85,7 +85,7 @@ class Config:
     """
 
     extra_paths: list[str] = _dataclasses.field(default_factory=lambda: [])
-    """List of extra paths to be analyzed by the sessions.
+    """The list of extra paths to be analyzed by the sessions.
 
     These are not inspected for packages, as they are passed verbatim to the
     tools invoked by the sessions.

--- a/src/frequenz/repo/config/nox/config.py
+++ b/src/frequenz/repo/config/nox/config.py
@@ -4,12 +4,13 @@
 """Configuration utilities for nox.
 
 This module provides utilities to configure the nox sessions. It provides a
-`Config` and a `CommandsOptions` class, which are used to configure the nox sessions.
+[`Config`][.Config] and a [`CommandsOptions`][.CommandsOptions] class, which are used to
+configure the nox sessions.
 
-The `get()` function can be used to retrieve the current configuration object
+The [`get()`][.get] function can be used to retrieve the current configuration object
 so it can be used when implementing custom nox sessions.
 
-The `configure()` function must be called before `get()` is used.
+The [`configure()`][.configure] function must be called before [`get()`][.get] is used.
 """
 
 import dataclasses as _dataclasses
@@ -124,8 +125,8 @@ class Config:
         """Return the file paths to run the checks on.
 
         If positional arguments are present in the nox session, those are used
-        as the file paths verbatim, and if not, all **existing** `source_paths`
-        and `extra_paths` are used.
+        as the file paths verbatim, and if not, all **existing** [`source_paths`][..source_paths]
+        and [`extra_paths`][..extra_paths] are used.
 
         Args:
             session: The nox session to use to look for command-line arguments.
@@ -154,7 +155,7 @@ _CONFIG: Config | None = None
 def get() -> Config:
     """Get the global configuration object.
 
-    This will assert if `configure()` wasn't called before.
+    This will assert if [`configure()`][..configure] wasn't called before.
 
     Returns:
         The global configuration object.

--- a/src/frequenz/repo/config/nox/config.py
+++ b/src/frequenz/repo/config/nox/config.py
@@ -198,7 +198,7 @@ def configure(
 
     Args:
         conf: The configuration to use to configure nox, or the repository type to use
-            to configure nox.  The later will use the default configuration in
+            to configure nox.  The latter will use the default configuration in
             [`frequenz.repo.config.nox.default`][] for that type of repository.
         import_default_sessions: Whether to import the default sessions or not.
             This is only necessary if you want to avoid using the default provided

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -42,7 +42,7 @@ common_command_options: _config.CommandsOptions = _config.CommandsOptions(
     mypy=[],
     pytest=[],
 )
-"""Default command-line options for all types of repositories."""
+"""The default command-line options for all types of repositories."""
 
 common_config = _config.Config(
     opts=common_command_options.copy(),
@@ -65,19 +65,19 @@ common_config = _config.Config(
         "tests",
     ],
 )
-"""Default configuration for all types of repositories."""
+"""The default configuration for all types of repositories."""
 
 actor_command_options: _config.CommandsOptions = common_command_options.copy()
-"""Default command-line options for actors."""
+"""The default command-line options for actors."""
 
 actor_config: _config.Config = common_config.copy()
-"""Default configuration for actors."""
+"""The default configuration for actors."""
 
 api_command_options: _config.CommandsOptions = common_command_options.copy()
-"""Default command-line options for APIs."""
+"""The default command-line options for APIs."""
 
 api_config: _config.Config = common_config.copy()
-"""Default configuration for APIs.
+"""The default configuration for APIs.
 
 Same as [`common_config`][..common_config], but with an empty `source_paths` (as the
 sources are automatically generated, we don't want to test anything in there).
@@ -87,19 +87,19 @@ sources are automatically generated, we don't want to test anything in there).
 api_config.source_paths = []
 
 app_command_options: _config.CommandsOptions = common_command_options.copy()
-"""Default command-line options for applications."""
+"""The default command-line options for applications."""
 
 app_config: _config.Config = common_config.copy()
-"""Default configuration for applications."""
+"""The default configuration for applications."""
 
 lib_command_options: _config.CommandsOptions = common_command_options.copy()
-"""Default command-line options for libraries."""
+"""The default command-line options for libraries."""
 
 lib_config: _config.Config = common_config.copy()
-"""Default configuration for libraries."""
+"""The default configuration for libraries."""
 
 model_command_options: _config.CommandsOptions = common_command_options.copy()
-"""Default command-line options for models."""
+"""The default command-line options for models."""
 
 model_config: _config.Config = common_config.copy()
-"""Default configuration for models."""
+"""The default configuration for models."""

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -7,16 +7,20 @@ This module provides the default configuration for the different types of
 repositories defined by
 [`frequenz.repo.config.RepositoryType`][frequenz.repo.config.RepositoryType].
 
-The `actor_config`, `api_config`, `app_config`, `lib_config`, and `model_config`
-variables are the default configurations for libraries, APIs, actors and applications,
-respectively. The `common_config` variable is the default configuration for all types of
+The [`actor_config`][.actor_config], [`api_config`][.api_config],
+[`app_config`][.app_config], [`lib_config`][.lib_config], and
+[`model_config`][.model_config] variables are the default configurations for actors,
+APIs, applications, libraries, and models, respectively. The
+[`common_config`][.common_config] variable is the default configuration for all types of
 repositories.
 
-The `actor_command_options`, `api_command_options`, `app_command_options`,
-`lib_command_options`, and `model_command_options` variables are the default
+The [`actor_command_options`][.actor_command_options],
+[`api_command_options`][.api_command_options], [`app_command_options`][.app_command_options],
+[`lib_command_options`][.lib_command_options], and
+[`model_command_options`][.model_command_options] variables are the default
 command-line options for the same types of repositories, and the
-`common_command_options` variable is the default command-line options for all types of
-repositories.
+[`common_command_options`][.common_command_options] variable is the default command-line
+options for all types of repositories.
 
 They can be modified before being passed to
 [`nox.configure()`][frequenz.repo.config.nox.configure] by using the
@@ -75,8 +79,8 @@ api_command_options: _config.CommandsOptions = common_command_options.copy()
 api_config: _config.Config = common_config.copy()
 """Default configuration for APIs.
 
-Same as `common_config`, but with an empty `source_paths` (as the sources are
-automatically generated, we don't want to test anything in there).
+Same as [`common_config`][..common_config], but with an empty `source_paths` (as the
+sources are automatically generated, we don't want to test anything in there).
 """
 
 # We don't check the sources at all because they are automatically generated.

--- a/src/frequenz/repo/config/nox/default.py
+++ b/src/frequenz/repo/config/nox/default.py
@@ -5,7 +5,7 @@
 
 This module provides the default configuration for the different types of
 repositories defined by
-[`frequenz.repo.config.RepositoryType`][frequenz.repo.config.RepositoryType].
+[`RepositoryType`][...RepositoryType].
 
 The [`actor_config`][.actor_config], [`api_config`][.api_config],
 [`app_config`][.app_config], [`lib_config`][.lib_config], and
@@ -23,8 +23,8 @@ command-line options for the same types of repositories, and the
 options for all types of repositories.
 
 They can be modified before being passed to
-[`nox.configure()`][frequenz.repo.config.nox.configure] by using the
-[`CommandsOptions.copy()`][frequenz.repo.config.nox.config.CommandsOptions.copy]
+[`nox.configure()`][..configure] by using the
+[`CommandsOptions.copy()`][..config.CommandsOptions.copy]
 method.
 """
 

--- a/src/frequenz/repo/config/nox/session.py
+++ b/src/frequenz/repo/config/nox/session.py
@@ -3,7 +3,7 @@
 
 """Predefined nox sessions.
 
-This module defines the predefined nox sessions that are used by the default.
+This module defines the predefined nox sessions that are used by default.
 """
 
 import nox

--- a/src/frequenz/repo/config/nox/session.py
+++ b/src/frequenz/repo/config/nox/session.py
@@ -18,7 +18,8 @@ def ci_checks_max(session: nox.Session) -> None:
 
     This is faster than running the checks separately, so it is suitable for CI.
 
-    This does NOT run pytest_min, so that needs to be run separately as well.
+    This does NOT run [`pytest_min`][..pytest_min], so that needs to be run separately as
+    well.
 
     Args:
         session: the nox session.

--- a/src/frequenz/repo/config/nox/util.py
+++ b/src/frequenz/repo/config/nox/util.py
@@ -138,7 +138,7 @@ def find_toplevel_package_dirs(
             `root`.
 
     Returns:
-        The top-level paths that contains a `__init__.py` file, with `root`
+        The top-level paths that contain a `__init__.py` file, with `root`
         removed.
 
     Examples:

--- a/src/frequenz/repo/config/nox/util.py
+++ b/src/frequenz/repo/config/nox/util.py
@@ -80,7 +80,7 @@ def existing_paths(paths: Iterable[str], /) -> Iterable[_pathlib.Path]:
 
 
 def is_python_file(path: _pathlib.Path, /) -> bool:
-    """Check if a path is a Python file.
+    """Return whether a path is a Python file.
 
     Args:
         path: The path to check.

--- a/src/frequenz/repo/config/nox/util.py
+++ b/src/frequenz/repo/config/nox/util.py
@@ -24,8 +24,8 @@ def flatten(iterables: Iterable[Iterable[_T]], /) -> Iterable[_T]:
     Returns:
         The flattened iterable.
 
-    Example:
-        >>> assert list(flatten([(1, 2), (3, 4)]) == [1, 2, 3, 4]
+    Examples:
+        >>> assert list(flatten([(1, 2), (3, 4)])) == [1, 2, 3, 4]
     """
     return (item for sublist in iterables for item in sublist)
 
@@ -40,7 +40,7 @@ def replace(iterable: Iterable[_T], replacements: Mapping[_T, _T], /) -> Iterabl
     Yields:
         The next element in the iterable, with the replacements applied.
 
-    Example:
+    Examples:
         >>> assert list(replace([1, 2, 3], {1: 4, 2: 5})) == [4, 5, 3]
     """
     for item in iterable:
@@ -73,7 +73,8 @@ def existing_paths(paths: Iterable[str], /) -> Iterable[_pathlib.Path]:
     Returns:
         An iterable with the valid paths as `pathlib.Path` objects.
 
-    Example:
+    Examples:
+        >>> import pathlib
         >>> assert list(existing_paths([".", "/fake"])) == [pathlib.Path(".")]
     """
     return deduplicate(p for p in map(_pathlib.Path, paths) if p.exists())

--- a/src/frequenz/repo/config/nox/util.py
+++ b/src/frequenz/repo/config/nox/util.py
@@ -181,10 +181,10 @@ def min_dependencies() -> list[str]:
     """Extract the minimum dependencies from pyproject.toml.
 
     Returns:
-        The minimun dependencies defined in pyproject.toml.
+        The minimum dependencies defined in pyproject.toml.
 
     Raises:
-        RuntimeError: If minimun dependencies are not properly set in pyproject.toml.
+        RuntimeError: If minimum dependencies are not properly set in pyproject.toml.
     """
     with open("pyproject.toml", "rb") as toml_file:
         data = _tomllib.load(toml_file)
@@ -212,7 +212,7 @@ def discover_paths() -> list[str]:
 
     Currently the following paths are discovered:
 
-    - The `testpaths` option in the `tools.pytest.ini_options` section of
+    - The `testpaths` option in the `tool.pytest.ini_options` section of
       `pyproject.toml`.
 
     Returns:

--- a/src/frequenz/repo/config/protobuf.py
+++ b/src/frequenz/repo/config/protobuf.py
@@ -18,7 +18,7 @@ class ProtobufConfig:
     """A configuration for the protobuf files.
 
     The configuration can be loaded from the `pyproject.toml` file using the class
-    method `from_pyproject_toml()`.
+    method [`from_pyproject_toml()`][.from_pyproject_toml].
     """
 
     proto_path: str = "proto"

--- a/src/frequenz/repo/config/pytest/__init__.py
+++ b/src/frequenz/repo/config/pytest/__init__.py
@@ -7,6 +7,6 @@ This package contains utilities for testing with [`pytest`](https://pypi.org/pro
 
 The following modules are available:
 
-- [`examples`][frequenz.repo.config.pytest.examples]: Utilities to enable linting of
+- [`examples`][.examples]: Utilities to enable linting of
   code examples in docstrings.
 """

--- a/src/frequenz/repo/config/pytest/examples.py
+++ b/src/frequenz/repo/config/pytest/examples.py
@@ -108,7 +108,7 @@ class _CustomPythonCodeBlockParser(CodeBlockParser):
     It uses pylint to validate the extracted code examples.
 
     All code examples are preceded by the original file's import statements as
-    well as an wildcard import of the file itself.
+    well as a wildcard import of the file itself.
     This allows us to use the code examples as if they were part of the original
     file.
 

--- a/src/frequenz/repo/config/pytest/examples.py
+++ b/src/frequenz/repo/config/pytest/examples.py
@@ -7,7 +7,7 @@ Code examples are often wrapped in triple backticks (````python`) within our doc
 This plugin extracts these code examples and validates them using pylint.
 
 The main utility function is
-[`get_sybil_arguments()`][frequenz.repo.config.pytest.examples.get_sybil_arguments],
+[`get_sybil_arguments()`][.get_sybil_arguments],
 which returns a dictionary that can be used to pass to the [`Sybil()`][sybil.Sybil]
 constructor.
 

--- a/src/frequenz/repo/config/pytest/examples.py
+++ b/src/frequenz/repo/config/pytest/examples.py
@@ -101,7 +101,7 @@ def _path_to_import_statement(path: Path) -> str:
 
 
 class _CustomPythonCodeBlockParser(CodeBlockParser):
-    """Code block parser that validates extracted code examples using pylint.
+    """A code block parser that validates extracted code examples using pylint.
 
     This parser is a modified version of the default Python code block parser
     from the Sybil library.
@@ -212,11 +212,12 @@ def _validate_with_pylint(
 
 
 class MyPythonCodeBlockParser(PythonCodeBlockParser):
-    """Custom Python code block parser that uses the custom code block parser."""
+    """A custom Python code block parser that uses the custom code block parser."""
 
     codeblock_parser_class: type[_CustomPythonCodeBlockParser] = (
         _CustomPythonCodeBlockParser
     )
+    """The code block parser class used to validate the examples."""
 
 
 def get_sybil_arguments() -> dict[str, Any]:

--- a/src/frequenz/repo/config/setuptools/grpc_tools.py
+++ b/src/frequenz/repo/config/setuptools/grpc_tools.py
@@ -1,7 +1,7 @@
 # License: MIT
 # Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
-"""Setuptool hooks to build protobuf files.
+"""Setuptools hooks to build protobuf files.
 
 This module contains a setuptools command that can be used to compile protocol
 buffer files in a project.

--- a/src/frequenz/repo/config/setuptools/grpc_tools.py
+++ b/src/frequenz/repo/config/setuptools/grpc_tools.py
@@ -23,7 +23,7 @@ from .. import protobuf as _protobuf
 
 
 class CompileProto(_setuptools.Command):
-    """Build the Python protobuf files."""
+    """A command to build the Python protobuf files."""
 
     proto_path: str
     """The path of the root directory containing the protobuf files."""
@@ -32,13 +32,13 @@ class CompileProto(_setuptools.Command):
     """The glob pattern to use to find the protobuf files."""
 
     include_paths: str | Iterable[str]
-    """Iterable or comma-separated list of paths to include when compiling the protobuf files."""
+    """The iterable or comma-separated list of paths to include when compiling protobuf files."""
 
     py_path: str
     """The path of the root directory where the Python files will be generated."""
 
     description: str = "compile protobuf files"
-    """Description of the command."""
+    """The description of the command."""
 
     # We need the cast here because Command.user_options has the type annoatation
     # ClassVar[list[tuple[str, str, str]] | list[tuple[str, str | None, str]]] but the
@@ -65,7 +65,7 @@ class CompileProto(_setuptools.Command):
             ),
         ],
     )
-    """Options of the command."""
+    """The options of the command."""
 
     def initialize_options(self) -> None:
         """Initialize options."""

--- a/src/frequenz/repo/config/version.py
+++ b/src/frequenz/repo/config/version.py
@@ -420,15 +420,15 @@ class RepoVersionInfo:  # pylint: disable=too-many-instance-attributes
         return bigger_tag.minor + 1
 
     def is_tag(self) -> bool:
-        """Tell whether we are at a stable release."""
+        """Return whether we are at a stable release."""
         return self._ref.startswith("refs/tags/")
 
     def is_branch(self) -> bool:
-        """Tell whether we are at a major branch."""
+        """Return whether we are at a branch."""
         return self._ref.startswith("refs/heads/")
 
     def is_tag_last_minor_for_major(self) -> bool:
-        """Tell whether the current tag is the last minor version for the major version.
+        """Return whether the current tag is the last minor version for the major version.
 
         If we are not at a tag or there are not tags in the repo, return `False`.
 
@@ -459,7 +459,7 @@ class RepoVersionInfo:  # pylint: disable=too-many-instance-attributes
         return tag >= max(minor_tags, key=lambda tag_: tag_.minor)
 
     def is_tag_latest(self) -> bool:
-        """Tell whether the current tag is the latest tag.
+        """Return whether the current tag is the latest tag.
 
         The latest tag is the tag with the biggest major, minor and patch
         version. If the current tag is a prerelease, then only prereleases are used to
@@ -493,7 +493,7 @@ class RepoVersionInfo:  # pylint: disable=too-many-instance-attributes
         return tag == latest[0]
 
     def is_branch_latest(self) -> bool:
-        """Tell whether the current branch is the latest.
+        """Return whether the current branch is the latest.
 
         The latest branch is the branch with the biggest major and minor, but if minor
         is `None`, then it is considered the biggest minor.

--- a/src/frequenz/repo/config/version.py
+++ b/src/frequenz/repo/config/version.py
@@ -193,7 +193,7 @@ class BranchVersion:
         return self.name
 
     def __lt__(self, other: BranchVersion) -> bool:
-        """Compare two branch version information.
+        """Compare two branch versions.
 
         If `minor` is `None`, it is considered to be greater than any other `minor`.
 
@@ -250,7 +250,7 @@ class RepoVersionInfo:  # pylint: disable=too-many-instance-attributes
         tags: list[str] | None = None,
         branches: list[str] | None = None,
     ) -> None:
-        """Initialize the environment variables.
+        """Initialize the repository version information.
 
         Args:
             sha: The current commit hash.

--- a/src/frequenz/repo/config/version.py
+++ b/src/frequenz/repo/config/version.py
@@ -4,7 +4,7 @@
 """Version information for a repository.
 
 This module provides the
-[`RepoVersionInfo`][frequenz.repo.config.version.RepoVersionInfo] class to get information
+[`RepoVersionInfo`][.RepoVersionInfo] class to get information
 about the repository version.
 
 It handles many scenarios and queries, like:
@@ -18,11 +18,11 @@ It handles many scenarios and queries, like:
 
 Repository tag names are expected to follow the [semantic versioning][semver]
 specification, but usually with a leading `v` (e.g. `v1.0.0`).
-[`to_semver()`][frequenz.repo.config.version.to_semver] can be used to convert a version
+[`to_semver()`][.to_semver] can be used to convert a version
 string to a semantic version, even if it has a leading `v`.
 
 Repository branch names can be parsed with
-[`BranchVersion.parse()`][frequenz.repo.config.version.BranchVersion.parse] and are
+[`BranchVersion.parse()`][.BranchVersion.parse] and are
 expected to follow the format:
 
 - `vX.x.x` for major branches, where `X` is the major version number. For example,
@@ -331,7 +331,7 @@ class RepoVersionInfo:  # pylint: disable=too-many-instance-attributes
 
         Returns:
             If we are at a tag, return the [current
-                tag][frequenz.repo.config.version.RepoVersionInfo.current_tag]. If we
+                tag][..current_tag]. If we
                 are at a branch, return the last tag matching the branch major and minor
                 (if any). If there are no matching tags, return `None`.
         """

--- a/src/frequenz/repo/config/version.py
+++ b/src/frequenz/repo/config/version.py
@@ -23,7 +23,7 @@ string to a semantic version, even if it has a leading `v`.
 
 Repository branch names can be parsed with
 [`BranchVersion.parse()`][frequenz.repo.config.version.BranchVersion.parse] and are
-expected follow the format:
+expected to follow the format:
 
 - `vX.x.x` for major branches, where `X` is the major version number. For example,
   `v1.x.x` is the major branch for the major version 1.


### PR DESCRIPTION
🤖 This pull request is part of an automated effort to improve the docstring documentation of all our projects.

Main issues being resolved:
- Typos in docstrings (including a wrong \`tools.pytest\` config section name and \`mkdocs-literary-nav\` plugin name)
- Grammatical mistakes, missing words and unclear wording
- Boolean accessor summaries using "Tell whether ..." / "Check if ..." instead of "Return whether ..."
- Class and attribute summaries not using the conventional noun-phrase mood ("A ..." / "The ...")
- Missing \`Args:\` and \`Raises:\` sections (and a placeholder "Post init." summary)
- Bare backtick symbol mentions that should be cross-reference links
- Absolute cross-references replaced with relative ones where applicable
- Macro variable names that used link syntax but are not Python symbols
- Broken code examples (unbalanced parentheses, missing import)

Other things to note:
- \`relative_crossrefs: true\` was added to the mkdocstrings options in \`mkdocs.yml\` as part of the rolling-out of relative cross-reference conventions.
- \`check-style-mismatch\` and \`require-inline-class-var-docs\` were added to the pydoclint config in \`pyproject.toml\`, and \`check-class-attributes\` was re-enabled (it had been disabled because the project documents attributes inline; \`require-inline-class-var-docs\` now enforces exactly that inline style, so the check is useful again). The source tree already complies with these checks.
- The \`nox/default.py\` module docstring described the default config variables with a "respectively" mapping that listed the repository types in the wrong order and omitted models; this was corrected.
- A copy-pasted summary in \`generate_protobuf_api_pages()\` that described Python modules instead of protocol buffer files was fixed.
- These changes only touch the \`frequenz.repo.config\` package's own docstrings and configuration. The equivalent \`cookiecutter/\` template files (and a corresponding \`migrate.py\` step) were intentionally left out of scope and may need a separate change to propagate the \`relative_crossrefs\` / pydoclint convention to generated repositories.