### PR TITLE
Update setuptools-scm to 10.2.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,36 +2,8 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-### Cookiecutter template
-
-All upgrading should be done via the migration script or regenerating the templates.
-
-```bash
-curl -sSLf https://raw.githubusercontent.com/frequenz-floss/frequenz-repo-config-python/<tag>/cookiecutter/migrate.py | python3 -I
-```
-
-But you might still need to adapt your code:
-
-<!-- Here upgrade steps for cookiecutter specifically -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-### Cookiecutter template
-
-<!-- Here new features for cookiecutter specifically -->
+This release fixes the building of distribution packages.
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
-
-### Cookiecutter template
-
-<!-- Here bug fixes for cookiecutter specifically -->
+- Fixed the building of distribution packages, which was failing with `setuptools-scm was unable to detect version`. When building a wheel from a source distribution there is no git repository to get the version from, so `setuptools-scm` 10.0.x reads it from `PKG-INFO` using an entry point provided by `vcs-versioning`, but it doesn't declare any upper bound for it. `vcs-versioning` 2.x dropped that entry point and moved the fallback to `setuptools-scm` itself, so builds started failing as soon as `vcs-versioning` 2.x was picked up. `setuptools-scm` was updated to 10.2.1, which provides the fallback again and bounds `vcs-versioning` to the 2.x series.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,36 @@
 
 ## Summary
 
-This release accepts the new setuptools 83.x series.
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+
+### Cookiecutter template
+
+All upgrading should be done via the migration script or regenerating the templates.
+
+```bash
+curl -sSLf https://raw.githubusercontent.com/frequenz-floss/frequenz-repo-config-python/<tag>/cookiecutter/migrate.py | python3 -I
+```
+
+But you might still need to adapt your code:
+
+<!-- Here upgrade steps for cookiecutter specifically -->
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+### Cookiecutter template
+
+<!-- Here new features for cookiecutter specifically -->
+
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+
+### Cookiecutter template
+
+<!-- Here bug fixes for cookiecutter specifically -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 [build-system]
-requires = ["setuptools == 83.0.0", "setuptools_scm[toml] == 10.0.5"]
+requires = ["setuptools == 83.0.0", "setuptools_scm[toml] == 10.2.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Building distribution packages was failing with `setuptools-scm was unable to detect version`, blocking the v0.18.1 release.

`python -m build` builds the sdist from the git checkout, and then rebuilds the wheel from the *unpacked sdist*, where there is no git repository to get the version from. In that case `setuptools-scm` 10.0.x reads the version from `PKG-INFO`, but it delegates that fallback to `vcs-versioning` (via the `setuptools_scm.parse_scm_fallback` entry point group) without declaring any upper bound for it.

`vcs-versioning` 2.x dropped that entry point group and replaced it with `vcs_versioning.discover_workdir`, moving the `PKG-INFO` factory into `setuptools-scm` itself (10.1.1+). So with `setuptools-scm == 10.0.5` and `vcs-versioning` 2.x, *nobody* registers the fallback anymore and the version can't be determined.

`setuptools-scm` is updated to 10.2.1, which registers the `pkginfo` factory itself and bounds `vcs-versioning` to the 2.x series.

Note this is unrelated to #616: `setuptools 82.0.1` fails identically, it just happened to be the first build after `vcs-versioning` 2.x became resolvable.

The full analysis is in https://github.com/frequenz-floss/frequenz-repo-config-python/issues/617#issuecomment-5254654050.

The cookiecutter templates are affected in exactly the same way, but they'll be updated in a separate PR based on `v0.x.x`.

Fixes #617.
